### PR TITLE
Handle incremental backfill without curated-gold sensor dependencies

### DIFF
--- a/airflow/dags/pipeline_serving_dags.py
+++ b/airflow/dags/pipeline_serving_dags.py
@@ -10,7 +10,6 @@ from airflow.operators.bash import BashOperator
 
 from pipeline_builders import (
     build_first_backfill_sensor,
-    build_curated_gold_sensor,
     build_merge_task,
     build_validate_bounds_task,
     build_validate_distinct_task,
@@ -51,8 +50,6 @@ def build_grid_operations_dag() -> DAG:
         end_expr = "{{ data_interval_end.in_timezone('UTC').isoformat() }}"
         wait_for_region_first_backfill = build_first_backfill_sensor("wait_for_region_first_backfill", "electricity_region_data")
         wait_for_fuel_first_backfill = build_first_backfill_sensor("wait_for_fuel_first_backfill", "electricity_fuel_type_data")
-        wait_for_region_gold = build_curated_gold_sensor("wait_for_region_curated_gold", "electricity_region_data")
-        wait_for_fuel_gold = build_curated_gold_sensor("wait_for_fuel_curated_gold", "electricity_fuel_type_data")
 
         build_stage = BashOperator(
             task_id="build_grid_operations_hourly_stage",
@@ -127,9 +124,7 @@ def build_grid_operations_dag() -> DAG:
             allow_empty_result=True,
         )
 
-        wait_for_region_first_backfill >> wait_for_fuel_first_backfill >> wait_for_region_gold
-        wait_for_fuel_first_backfill >> wait_for_fuel_gold
-        [wait_for_region_gold, wait_for_fuel_gold] >> build_stage
+        [wait_for_region_first_backfill, wait_for_fuel_first_backfill] >> build_stage
         build_stage >> validate_stage_rows >> merge_status >> merge_alerts >> validate_rows >> validate_respondents >> validate_coverage_ratio >> validate_renewable_share
 
     return dag
@@ -154,8 +149,6 @@ def build_resource_planning_dag() -> DAG:
         recent_where = "date >= current_date - interval '35 days'"
         wait_for_region_first_backfill = build_first_backfill_sensor("wait_for_region_first_backfill", "electricity_region_data")
         wait_for_fuel_first_backfill = build_first_backfill_sensor("wait_for_fuel_first_backfill", "electricity_fuel_type_data")
-        wait_for_region_gold = build_curated_gold_sensor("wait_for_region_curated_gold", "electricity_region_data")
-        wait_for_fuel_gold = build_curated_gold_sensor("wait_for_fuel_curated_gold", "electricity_fuel_type_data")
 
         build_stage = BashOperator(
             task_id="build_resource_planning_daily_stage",
@@ -222,9 +215,7 @@ def build_resource_planning_dag() -> DAG:
             allow_empty_result=True,
         )
 
-        wait_for_region_first_backfill >> wait_for_fuel_first_backfill >> wait_for_region_gold
-        wait_for_fuel_first_backfill >> wait_for_fuel_gold
-        [wait_for_region_gold, wait_for_fuel_gold] >> build_stage
+        [wait_for_region_first_backfill, wait_for_fuel_first_backfill] >> build_stage
         build_stage >> validate_stage_rows >> merge >> validate_rows >> validate_respondents >> validate_renewable_share >> validate_carbon_intensity
 
     return dag

--- a/airflow/tests/test_pipeline_builders_and_dataset_dags.py
+++ b/airflow/tests/test_pipeline_builders_and_dataset_dags.py
@@ -206,13 +206,11 @@ def test_serving_dag_builders_include_validation_chain(monkeypatch) -> None:  # 
     planning_dag = pipeline_serving_dags.build_resource_planning_dag()
 
     assert grid_dag.get_task("wait_for_region_first_backfill").upstream_task_ids == set()
-    assert grid_dag.get_task("wait_for_fuel_first_backfill").upstream_task_ids == {"wait_for_region_first_backfill"}
+    assert grid_dag.get_task("wait_for_fuel_first_backfill").upstream_task_ids == set()
     assert grid_dag.get_task("build_grid_operations_hourly_stage").upstream_task_ids == {
-        "wait_for_region_curated_gold",
-        "wait_for_fuel_curated_gold",
+        "wait_for_region_first_backfill",
+        "wait_for_fuel_first_backfill",
     }
-    assert grid_dag.get_task("wait_for_region_curated_gold").upstream_task_ids == {"wait_for_fuel_first_backfill"}
-    assert grid_dag.get_task("wait_for_fuel_curated_gold").upstream_task_ids == {"wait_for_fuel_first_backfill"}
     assert grid_dag.get_task("validate_grid_operations_renewable_share").upstream_task_ids == {"validate_grid_operations_coverage_ratio"}
     assert grid_dag.get_task("validate_grid_operations_rows").op_kwargs["allow_empty_result"] is True
     assert grid_dag.get_task("validate_grid_operations_respondents").op_kwargs["allow_empty_result"] is True
@@ -221,7 +219,11 @@ def test_serving_dag_builders_include_validation_chain(monkeypatch) -> None:  # 
     assert planning_dag.get_task("validate_resource_planning_carbon_intensity").upstream_task_ids == {
         "validate_resource_planning_renewable_share"
     }
-    assert planning_dag.get_task("wait_for_fuel_first_backfill").upstream_task_ids == {"wait_for_region_first_backfill"}
+    assert planning_dag.get_task("wait_for_fuel_first_backfill").upstream_task_ids == set()
+    assert planning_dag.get_task("build_resource_planning_daily_stage").upstream_task_ids == {
+        "wait_for_region_first_backfill",
+        "wait_for_fuel_first_backfill",
+    }
     assert planning_dag.get_task("validate_resource_planning_rows").op_kwargs["allow_empty_result"] is True
     assert planning_dag.get_task("validate_resource_planning_respondents").op_kwargs["allow_empty_result"] is True
     assert planning_dag.get_task("validate_resource_planning_renewable_share").op_kwargs["allow_empty_result"] is True

--- a/spark/common/io.py
+++ b/spark/common/io.py
@@ -45,6 +45,11 @@ def _is_retryable_missing_file_error(exc: Exception) -> bool:
     return "FileNotFoundException" in message or "No such file or directory" in message
 
 
+def _is_empty_parquet_schema_error(exc: Exception) -> bool:
+    message = str(exc)
+    return "UNABLE_TO_INFER_SCHEMA" in message or "Unable to infer schema for Parquet" in message
+
+
 def _read_with_retries(loader, *, retries: int, retry_delay_seconds: float):  # noqa: ANN001, ANN202
     attempts = retries + 1
     last_error: Exception | None = None
@@ -94,11 +99,16 @@ def read_parquet_if_exists(
 
     if not path_exists(spark, path_str):
         return None
-    return _read_with_retries(
-        lambda: spark.read.parquet(path_str),
-        retries=retries,
-        retry_delay_seconds=retry_delay_seconds,
-    )
+    try:
+        return _read_with_retries(
+            lambda: spark.read.parquet(path_str),
+            retries=retries,
+            retry_delay_seconds=retry_delay_seconds,
+        )
+    except Exception as exc:  # pragma: no cover - Spark raises environment-specific wrappers
+        if _is_empty_parquet_schema_error(exc):
+            return None
+        raise
 
 
 def write_partitioned_parquet(df: DataFrame, output_path: str, partition_column: str = "event_date") -> None:

--- a/spark/jobs/gold_region_fuel_serving_hourly.py
+++ b/spark/jobs/gold_region_fuel_serving_hourly.py
@@ -18,9 +18,9 @@ from pyspark.sql import functions as F
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from common.config import load_spark_app_config
-from common.io import read_parquet_if_exists, read_partitioned_parquet, write_partitioned_parquet
+from common.io import has_partitioned_parquet_input, read_parquet_if_exists, read_partitioned_parquet, write_partitioned_parquet
 from common.logging_utils import configure_logging, log_job_complete, log_job_start
-from common.quality import assert_no_conflicting_records, assert_no_nulls, assert_non_negative, assert_unique_keys
+from common.quality import assert_no_nulls, assert_non_negative, assert_unique_keys
 from common.spark_session import build_spark_session
 from common.windowing import filter_time_window
 
@@ -61,12 +61,8 @@ def parse_args() -> argparse.Namespace:
 def build_region_hourly_metrics(region_df: DataFrame) -> DataFrame:
     """Build the curated region demand and forecast Gold fact table."""
 
-    assert_no_conflicting_records(
-        region_df.filter(F.col("type").isin("D", "DF")),
-        ["period", "respondent", "type"],
-        ["respondent_name", "value", "value_units"],
-        "gold.fact_region_demand_forecast_hourly",
-    )
+    # Region rows can legitimately be revised across re-fetches for the same
+    # business key. Gold keeps the latest loaded version for each key.
     latest_window = Window.partitionBy("period", "respondent", "type").orderBy(F.col("loaded_at").desc(), F.col("event_id").desc())
     stable_region_df = region_df.withColumn("record_rank", F.row_number().over(latest_window)).filter(F.col("record_rank") == 1).drop("record_rank")
     demand_df = (
@@ -136,12 +132,8 @@ def build_region_hourly_metrics(region_df: DataFrame) -> DataFrame:
 def build_fuel_type_hourly_generation(fuel_df: DataFrame) -> DataFrame:
     """Build the curated fuel generation Gold fact table."""
 
-    assert_no_conflicting_records(
-        fuel_df,
-        ["period", "respondent", "fueltype"],
-        ["respondent_name", "fueltype_name", "value", "value_units"],
-        "gold.fact_fuel_generation_hourly",
-    )
+    # Fuel rows can also be revised across re-fetches. Keep the latest version
+    # per hourly business key before writing curated output.
     latest_window = Window.partitionBy("period", "respondent", "fueltype").orderBy(F.col("loaded_at").desc(), F.col("event_id").desc())
     gold_df = (
         fuel_df.withColumn("record_rank", F.row_number().over(latest_window))
@@ -362,26 +354,44 @@ def main() -> None:
     fuel_df: DataFrame | None = None
 
     if args.dataset in {"electricity_region_data", "all"}:
-        region_df = read_partitioned_parquet(
-            spark,
-            f"{args.silver_base_path}/region_data",
-            retries=SILVER_READ_RETRIES,
-            retry_delay_seconds=SILVER_READ_RETRY_DELAY_SECONDS,
-        )
-        region_df = filter_time_window(region_df, "period", args.start, args.end)
-        region_gold_df = build_region_hourly_metrics(region_df)
-        write_partitioned(region_gold_df, args.region_fact_path)
+        region_input_path = f"{args.silver_base_path}/region_data"
+        if has_partitioned_parquet_input(spark, region_input_path):
+            region_df = read_partitioned_parquet(
+                spark,
+                region_input_path,
+                retries=SILVER_READ_RETRIES,
+                retry_delay_seconds=SILVER_READ_RETRY_DELAY_SECONDS,
+            )
+            region_df = filter_time_window(region_df, "period", args.start, args.end)
+            region_gold_df = build_region_hourly_metrics(region_df)
+            write_partitioned(region_gold_df, args.region_fact_path)
+        else:
+            logger.info(
+                "Skipping Gold region fact build because no Silver input is available input_path=%s start=%s end=%s",
+                region_input_path,
+                args.start,
+                args.end,
+            )
 
     if args.dataset in {"electricity_fuel_type_data", "all"}:
-        fuel_df = read_partitioned_parquet(
-            spark,
-            f"{args.silver_base_path}/fuel_type_data",
-            retries=SILVER_READ_RETRIES,
-            retry_delay_seconds=SILVER_READ_RETRY_DELAY_SECONDS,
-        )
-        fuel_df = filter_time_window(fuel_df, "period", args.start, args.end)
-        fuel_gold_df = build_fuel_type_hourly_generation(fuel_df)
-        write_partitioned(fuel_gold_df, args.fuel_fact_path)
+        fuel_input_path = f"{args.silver_base_path}/fuel_type_data"
+        if has_partitioned_parquet_input(spark, fuel_input_path):
+            fuel_df = read_partitioned_parquet(
+                spark,
+                fuel_input_path,
+                retries=SILVER_READ_RETRIES,
+                retry_delay_seconds=SILVER_READ_RETRY_DELAY_SECONDS,
+            )
+            fuel_df = filter_time_window(fuel_df, "period", args.start, args.end)
+            fuel_gold_df = build_fuel_type_hourly_generation(fuel_df)
+            write_partitioned(fuel_gold_df, args.fuel_fact_path)
+        else:
+            logger.info(
+                "Skipping Gold fuel fact build because no Silver input is available input_path=%s start=%s end=%s",
+                fuel_input_path,
+                args.start,
+                args.end,
+            )
 
     if region_df is not None or fuel_df is not None:
         respondent_dim_df = build_respondent_dimension(spark, region_df, fuel_df, args.respondent_dim_path)

--- a/spark/tests/test_gold_platinum_cli.py
+++ b/spark/tests/test_gold_platinum_cli.py
@@ -1,3 +1,6 @@
+from types import SimpleNamespace
+
+import jobs.gold_region_fuel_serving_hourly as gold_job
 from jobs.gold_region_fuel_serving_hourly import parse_args as parse_gold_args
 from jobs.platinum_region_demand_daily import parse_args as parse_platinum_args
 
@@ -20,3 +23,27 @@ def test_parse_platinum_args_defaults(monkeypatch) -> None:  # noqa: ANN001
     assert args.gold_input_path.startswith("s3a://gold/")
     assert args.platinum_table.startswith("platinum.")
     assert args.stage_table.startswith("platinum.")
+
+
+def test_gold_main_skips_missing_partitioned_input(monkeypatch) -> None:  # noqa: ANN001
+    monkeypatch.setattr(
+        "sys.argv",
+        ["gold_region_fuel_serving_hourly.py", "--dataset", "electricity_fuel_type_data"],
+    )
+    monkeypatch.setattr(gold_job, "configure_logging", lambda: None)
+    monkeypatch.setattr(gold_job, "load_spark_app_config", lambda: SimpleNamespace())
+    monkeypatch.setattr(gold_job, "build_spark_session", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(gold_job, "has_partitioned_parquet_input", lambda *_args, **_kwargs: False)
+    monkeypatch.setattr(gold_job, "log_job_start", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(gold_job, "log_job_complete", lambda *_args, **_kwargs: None)
+
+    read_calls: list[tuple[object, str]] = []
+    monkeypatch.setattr(
+        gold_job,
+        "read_partitioned_parquet",
+        lambda spark, path, **_kwargs: read_calls.append((spark, path)),
+    )
+
+    gold_job.main()
+
+    assert read_calls == []

--- a/spark/tests/test_quality_io_windowing.py
+++ b/spark/tests/test_quality_io_windowing.py
@@ -169,6 +169,13 @@ def test_read_partitioned_parquet_preserves_partition_columns(spark_session, tmp
     assert row["event_date"] == expected_date
 
 
+def test_read_parquet_if_exists_returns_none_for_empty_existing_directory(spark_session, tmp_path) -> None:
+    empty_dir = tmp_path / "empty_parquet_dir"
+    empty_dir.mkdir()
+
+    assert spark_io.read_parquet_if_exists(spark_session, str(empty_dir)) is None
+
+
 def test_build_spark_session_configures_expected_defaults(monkeypatch) -> None:  # noqa: ANN001
     builder = FakeBuilder()
     monkeypatch.setattr("common.spark_session.SparkSession.builder", builder, raising=False)

--- a/spark/tests/test_transforms.py
+++ b/spark/tests/test_transforms.py
@@ -85,7 +85,7 @@ def test_region_hourly_metrics_aggregates_by_period_and_respondent(spark_session
     assert rows[0]["day_ahead_forecast_mwh"] == 125.0
 
 
-def test_region_hourly_metrics_rejects_conflicting_duplicates(spark_session) -> None:
+def test_region_hourly_metrics_prefers_latest_loaded_conflicting_duplicate(spark_session) -> None:
     region_df = spark_session.createDataFrame(
         [
             {
@@ -113,8 +113,11 @@ def test_region_hourly_metrics_rejects_conflicting_duplicates(spark_session) -> 
         ]
     )
 
-    with pytest.raises(ValueError, match="conflicting records"):
-        build_region_hourly_metrics(region_df)
+    gold_df = build_region_hourly_metrics(region_df)
+    rows = gold_df.collect()
+
+    assert len(rows) == 1
+    assert rows[0]["actual_demand_mwh"] == 120.0
 
 
 def test_respondent_dimension_rolls_up_current_and_historical_names(spark_session, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- remove brittle curated-gold sensor dependencies from the serving DAGs
- let Gold jobs skip cleanly when partitioned Silver input is missing
- harden Gold/IO behavior for revised rows and empty parquet directories

## Testing
- pytest -q airflow/tests/test_pipeline_builders_and_dataset_dags.py spark/tests/test_gold_platinum_cli.py
- pytest -q spark/tests/test_transforms.py spark/tests/test_quality_io_windowing.py spark/tests/test_gold_platinum_cli.py
- python -m compileall airflow\\dags spark\\jobs
- python -m compileall spark\\common spark\\jobs