### PR TITLE
Align EIA windows and run fuel incremental daily

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Backfill is triggered after successful incrementals and also has an hourly safet
 - Bronze is replay-safe by `event_id` and stores hourly partitions beneath each dataset path.
 - Bronze verification and repair DAGs are currently disabled from active orchestration and remain on disk only for future reuse.
 - Incremental DAGs now seed backfill runs, and backfill execution is globally serialized to reduce machine load.
+- `electricity_region_data_incremental` remains hourly, while `electricity_fuel_type_data_incremental` now runs daily at `18:20 UTC` because the fuel source can lag well behind the current hour.
 - Backfill DAGs retry transient failures automatically, and stale in-progress backfill jobs are requeued up to a capped attempt count.
 - Fuel incremental validation no longer fails when an hourly source window legitimately returns no new valid rows.
 - Gold now materializes explicit fact datasets at `s3a://gold/facts/region_demand_forecast_hourly` and `s3a://gold/facts/fuel_generation_hourly`.
@@ -98,6 +99,13 @@ Backfill is triggered after successful incrementals and also has an hourly safet
 - Platinum DAGs wait for one completed backfill chunk from both datasets before their first successful runs, then continue on hourly incremental curated-gold dependencies.
 - Silver and Gold remain day-partitioned by design.
 - Backfill operations should use normal scheduling or `airflow dags trigger`, not `airflow dags test`.
+
+## Windowing and Bronze Notes
+
+- Ingestion fetch windows now follow `[start, end)` semantics. Airflow and Spark pass an exclusive `end`, and the ingestion layer translates that into the inclusive EIA API boundary internally.
+- Bronze counts can differ from a current API snapshot for two reasons:
+  - a prior boundary-hour over-fetch bug, now fixed by the ingestion window translation
+  - intentional append-only retention of revised EIA rows by `event_id`, which remains unchanged
 
 ## Useful Checks
 

--- a/admin_app/airflow_store.py
+++ b/admin_app/airflow_store.py
@@ -16,6 +16,8 @@ LOG_PATH_PATTERN = re.compile(
 
 
 def expected_lag_for_dag(dag_id: str) -> timedelta:
+    if dag_id == "electricity_fuel_type_data_incremental":
+        return timedelta(hours=26)
     if dag_id.endswith("_incremental"):
         return timedelta(hours=2)
     if dag_id.endswith("_backfill"):

--- a/admin_app/tests/test_airflow_store.py
+++ b/admin_app/tests/test_airflow_store.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from pathlib import Path
 from airflow_store import AirflowStore, expected_lag_for_dag, extract_error_excerpt
 from config import AppConfig
@@ -47,6 +48,8 @@ def test_extract_error_excerpt_and_read_task_log(tmp_path: Path) -> None:
 
 
 def test_expected_lag_and_fallback_excerpt() -> None:
+    assert expected_lag_for_dag("electricity_fuel_type_data_incremental") == timedelta(hours=26)
+    assert expected_lag_for_dag("electricity_region_data_incremental") == timedelta(hours=2)
     assert expected_lag_for_dag("electricity_region_data_backfill").seconds == 1200
     excerpt = extract_error_excerpt("line1\nline2\nline3")
     assert excerpt == "line1\nline2\nline3"

--- a/airflow/README.md
+++ b/airflow/README.md
@@ -1,7 +1,16 @@
 # Airflow
 
 ## Purpose
-This folder owns orchestration: hourly incrementals, historical backfills, disabled Bronze verification/repair code paths, and the platinum-serving DAG schedules.
+This folder owns orchestration: dataset incrementals, historical backfills, disabled Bronze verification/repair code paths, and the platinum-serving DAG schedules.
+
+## Current Scheduling Notes
+- `electricity_region_data_incremental` runs hourly.
+- `electricity_fuel_type_data_incremental` runs daily at `18:20 UTC`.
+- Dataset fetch commands use pipeline windows with `[start, end)` semantics even though the upstream EIA API expects an inclusive `end`.
+
+## Bronze Mismatch Notes
+- Raw Bronze counts can be higher than a point-in-time API query because EIA can revise previously published business hours and Bronze keeps those distinct `event_id` records.
+- A separate boundary-hour over-fetch issue existed in ingestion and is now fixed by translating the exclusive pipeline `end` to the inclusive EIA API `end`.
 
 ## Important Files
 - `dags/pipeline_factories.py`: DAG registration facade.

--- a/airflow/dags/pipeline_dataset_dags.py
+++ b/airflow/dags/pipeline_dataset_dags.py
@@ -55,16 +55,17 @@ BACKFILL_DEFAULT_ARGS = {"retries": 1, "retry_delay": timedelta(minutes=5)}
 
 
 def build_incremental_dag(dataset_id: str, dataset: dict[str, str]) -> DAG:
-    """Build the hourly dataset DAG from ingestion through optional serving."""
+    """Build the dataset incremental DAG from ingestion through optional serving."""
 
     dag_id = f"{dataset_id}_incremental"
     has_serving = dataset_id == "electricity_region_data" and bool(dataset.get("platinum_table"))
     has_curated_gold = dataset_id in {"electricity_region_data", "electricity_fuel_type_data"}
+    incremental_schedule = dataset.get("incremental_schedule", "@hourly")
 
     with DAG(
         dag_id=dag_id,
         start_date=datetime(2024, 1, 1),
-        schedule="@hourly",
+        schedule=incremental_schedule,
         catchup=False,
         is_paused_upon_creation=True,
         max_active_runs=1,

--- a/airflow/tests/test_pipeline_builders_and_dataset_dags.py
+++ b/airflow/tests/test_pipeline_builders_and_dataset_dags.py
@@ -124,6 +124,7 @@ REGION_DATASET = {
     "bronze_output_path": "s3a://bronze/region",
     "bronze_checkpoint_path": "s3a://bronze/checkpoints/region",
     "platinum_table": "platinum.region_demand_daily",
+    "incremental_schedule": "@hourly",
 }
 
 FUEL_DATASET = {
@@ -131,6 +132,7 @@ FUEL_DATASET = {
     "topic": "eia_electricity_fuel_type_data",
     "bronze_output_path": "s3a://bronze/fuel",
     "bronze_checkpoint_path": "s3a://bronze/checkpoints/fuel",
+    "incremental_schedule": "20 18 * * *",
 }
 
 
@@ -176,6 +178,8 @@ def test_dataset_dag_builders_include_expected_tasks_for_region_and_fuel(monkeyp
     incremental_region = pipeline_dataset_dags.build_incremental_dag("electricity_region_data", REGION_DATASET)
     incremental_fuel = pipeline_dataset_dags.build_incremental_dag("electricity_fuel_type_data", FUEL_DATASET)
     backfill_region = pipeline_dataset_dags.build_backfill_dag("electricity_region_data", REGION_DATASET)
+    assert incremental_region.kwargs["schedule"] == "@hourly"
+    assert incremental_fuel.kwargs["schedule"] == "20 18 * * *"
     assert "spark_platinum_stage" in incremental_region.task_dict
     assert "spark_platinum_stage" not in incremental_fuel.task_dict
     assert incremental_region.get_task("spark_curated_gold_batch").downstream_task_ids == {"spark_platinum_stage"}

--- a/ingestion/src/dataset_registry.yml
+++ b/ingestion/src/dataset_registry.yml
@@ -3,6 +3,7 @@ datasets:
     route: electricity/rto/region-data
     topic: eia_electricity_region_data
     frequency: hourly
+    incremental_schedule: "@hourly"
     data_columns:
       - value
     default_facets:
@@ -22,6 +23,7 @@ datasets:
     route: electricity/rto/fuel-type-data
     topic: eia_electricity_fuel_type_data
     frequency: hourly
+    incremental_schedule: "20 18 * * *"
     data_columns:
       - value
     bronze_output_path: s3a://bronze/electricity_fuel_type_data

--- a/ingestion/src/eia_api.py
+++ b/ingestion/src/eia_api.py
@@ -7,6 +7,7 @@ into Kafka events.
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 import requests
@@ -23,6 +24,30 @@ def _apply_facets(params: dict[str, Any], facets: dict[str, list[str]] | None) -
         params[f"facets[{facet_name}][]"] = facet_values
 
 
+def _parse_cli_hour(value: str) -> datetime:
+    """Parse an ingestion CLI hour boundary and normalize it to UTC."""
+
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def resolve_api_window_bounds(start: str, end: str, frequency: str = "hourly") -> tuple[str, str]:
+    """Translate the pipeline's [start, end) window into EIA API parameters."""
+
+    start_dt = _parse_cli_hour(start)
+    end_dt = _parse_cli_hour(end)
+    if end_dt <= start_dt:
+        raise ValueError(f"Invalid source window: end must be greater than start (start={start}, end={end})")
+
+    if frequency == "hourly":
+        api_end = end_dt - timedelta(hours=1)
+        return start_dt.strftime("%Y-%m-%dT%H"), api_end.strftime("%Y-%m-%dT%H")
+
+    return start, end
+
+
 def build_eia_query_params(
     api_key: str,
     start: str,
@@ -37,8 +62,8 @@ def build_eia_query_params(
 
     Args:
         api_key: API key used to call EIA v2.
-        start: Inclusive start of the source window.
-        end: Inclusive end of the source window.
+        start: Inclusive start of the translated EIA API request window.
+        end: Inclusive end of the translated EIA API request window.
         offset: Row offset for pagination.
         length: Maximum rows to request for this page.
         default_facets: Dataset-specific filters from the registry.
@@ -84,8 +109,8 @@ def fetch_dataset_rows(
     Args:
         api_key: EIA API key.
         dataset_config: One dataset entry from `dataset_registry.yml`.
-        start: Inclusive source-window start.
-        end: Inclusive source-window end.
+        start: Inclusive pipeline source-window start.
+        end: Exclusive pipeline source-window end.
         page_size: Max rows per API page.
         max_pages: Hard stop to prevent unbounded paging.
         timeout_seconds: Per-request timeout.
@@ -101,6 +126,7 @@ def fetch_dataset_rows(
 
     route = dataset_config["route"]
     query_url = f"{EIA_API_BASE_URL}/{route}/data/"
+    api_start, api_end = resolve_api_window_bounds(start, end, dataset_config.get("frequency", "hourly"))
     offset = 0
     all_rows: list[dict[str, Any]] = []
     page_count = 0
@@ -110,8 +136,8 @@ def fetch_dataset_rows(
     while page_count < max_pages:
         params = build_eia_query_params(
             api_key=api_key,
-            start=start,
-            end=end,
+            start=api_start,
+            end=api_end,
             offset=offset,
             length=page_size,
             default_facets=dataset_config.get("default_facets"),

--- a/ingestion/src/fetch_eia.py
+++ b/ingestion/src/fetch_eia.py
@@ -14,8 +14,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from src.eia_api import build_eia_query_params, fetch_dataset_rows
-from src.event_factory import build_event, build_event_id
+from src.eia_api import fetch_dataset_rows
+from src.event_factory import build_event
 from src.publish_kafka import publish_events
 from src.registry import load_dataset_registry
 
@@ -23,16 +23,16 @@ logger = logging.getLogger(__name__)
 
 
 def parse_args() -> argparse.Namespace:
-    """Parse CLI arguments for the ingestion fetch command."""
+    """Parse CLI arguments for the ingestion fetch command using [start, end) windows."""
 
     now = datetime.now(timezone.utc)
     default_end = now.replace(minute=0, second=0, microsecond=0)
     default_start = default_end - timedelta(hours=24)
 
-    parser = argparse.ArgumentParser(description="Fetch EIA data and publish to Kafka.")
+    parser = argparse.ArgumentParser(description="Fetch EIA data and publish to Kafka using [start, end) source windows.")
     parser.add_argument("--dataset", help="Dataset id in registry; if omitted all datasets run.")
-    parser.add_argument("--start", default=default_start.strftime("%Y-%m-%dT%H"))
-    parser.add_argument("--end", default=default_end.strftime("%Y-%m-%dT%H"))
+    parser.add_argument("--start", default=default_start.strftime("%Y-%m-%dT%H"), help="Inclusive UTC hour boundary for the source window.")
+    parser.add_argument("--end", default=default_end.strftime("%Y-%m-%dT%H"), help="Exclusive UTC hour boundary for the source window.")
     parser.add_argument("--page-size", type=int, default=5000)
     parser.add_argument("--max-pages", type=int, default=500)
     parser.add_argument("--respondent", help="Optional respondent filter, example PJM.")

--- a/ingestion/tests/test_fetch_eia.py
+++ b/ingestion/tests/test_fetch_eia.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from src.eia_api import build_eia_query_params, fetch_dataset_rows
+from src.eia_api import build_eia_query_params, fetch_dataset_rows, resolve_api_window_bounds
 from src.event_factory import build_event, build_event_id
 from src.registry import load_dataset_registry, validate_dataset_registry
 
@@ -66,6 +66,15 @@ def test_build_query_params_applies_facets() -> None:
     assert params["sort[0][column]"] == "period"
 
 
+def test_resolve_api_window_bounds_converts_exclusive_hourly_end() -> None:
+    assert resolve_api_window_bounds("2026-03-15T14", "2026-03-15T15") == ("2026-03-15T14", "2026-03-15T14")
+
+
+def test_resolve_api_window_bounds_rejects_empty_or_negative_window() -> None:
+    with pytest.raises(ValueError, match="end must be greater than start"):
+        resolve_api_window_bounds("2026-03-15T14", "2026-03-15T14")
+
+
 def test_fetch_dataset_rows_paginates_until_total() -> None:
     session = FakeSession(
         responses=[
@@ -90,6 +99,7 @@ def test_fetch_dataset_rows_paginates_until_total() -> None:
     assert len(session.calls) == 2
     assert session.calls[1]["params"]["offset"] == 2
     assert session.calls[0]["params"]["data[0]"] == "value"
+    assert session.calls[0]["params"]["end"] == "2026-01-01T01"
 
 
 def test_fetch_dataset_rows_stops_when_page_is_short_without_total() -> None:

--- a/ingestion/tests/test_fetch_eia_cli.py
+++ b/ingestion/tests/test_fetch_eia_cli.py
@@ -38,6 +38,7 @@ def test_parse_args_and_select_datasets(monkeypatch) -> None:  # noqa: ANN001
     assert args.dataset == "electricity_region_data"
     assert args.respondent == "PJM"
     assert args.dry_run is True
+    assert "[start, end)" in fetch_eia.parse_args.__doc__
     assert [dataset["id"] for dataset in selected] == ["electricity_region_data", "electricity_fuel_type_data"]
 
     with pytest.raises(ValueError, match="Unknown dataset"):
@@ -88,6 +89,7 @@ def test_main_dry_run_builds_events_without_publishing(monkeypatch) -> None:  # 
 
     assert built_events[0]["dataset_id"] == "electricity_region_data"
     assert built_events[0]["source_window_start"] == "2026-03-10T00"
+    assert built_events[0]["source_window_end"] == "2026-03-10T02"
     assert published == []
 
 


### PR DESCRIPTION
## Summary
- align EIA ingestion windows with the pipeline's [start, end) semantics
- move electricity_fuel_type_data_incremental to a daily 18:20 UTC schedule and adjust admin DAG lag expectations
- document Bronze/API mismatch behavior without changing append-only Bronze retention

## Notes
- This PR is based on the current incremental/backfill fix branch, so it also includes these earlier branch commits relative to master:
  - 1c4acf0 Seed weekly backfill from incrementals and serialize backfill runs
  - 1eb3a61 Handle incremental backfill without curated-gold sensor dependencies

## Validation
- pytest -q ingestion/tests/test_fetch_eia.py ingestion/tests/test_fetch_eia_cli.py
- pytest -q airflow/tests/test_pipeline_builders_and_dataset_dags.py
- pytest -q admin_app/tests/test_airflow_store.py
