### PR TITLE
Fix region forecast coverage and same-day persistence

### DIFF
--- a/airflow/dags/pipeline_dataset_dags.py
+++ b/airflow/dags/pipeline_dataset_dags.py
@@ -68,7 +68,7 @@ def build_incremental_dag(dataset_id: str, dataset: dict[str, str]) -> DAG:
 
     cli_start_expr = "{{ data_interval_start.in_timezone('UTC').strftime('%Y-%m-%dT%H') }}"
     cli_end_expr = "{{ data_interval_end.in_timezone('UTC').strftime('%Y-%m-%dT%H') }}"
-    if dataset.get("frequency") != "hourly":
+    if dataset.get("frequency", "hourly") != "hourly":
         cli_start_expr = "{{ data_interval_start.in_timezone('UTC').isoformat() }}"
         cli_end_expr = "{{ data_interval_end.in_timezone('UTC').isoformat() }}"
 
@@ -84,6 +84,7 @@ def build_incremental_dag(dataset_id: str, dataset: dict[str, str]) -> DAG:
     ) as dag:
         start_expr = "{{ data_interval_start.in_timezone('UTC').isoformat() }}"
         end_expr = "{{ data_interval_end.in_timezone('UTC').isoformat() }}"
+        region_day_start_expr = "{{ data_interval_start.in_timezone('UTC').replace(hour=0, minute=0, second=0, microsecond=0).isoformat() }}"
 
         ingest = BashOperator(
             task_id="ingest_to_kafka",
@@ -169,9 +170,10 @@ def build_incremental_dag(dataset_id: str, dataset: dict[str, str]) -> DAG:
                 )
             else:
                 stage_table = "platinum.region_demand_daily_stage_{{ ts_nodash | lower }}"
+                platinum_start_expr = region_day_start_expr if dataset_id == "electricity_region_data" else start_expr
                 platinum = BashOperator(
                     task_id="spark_platinum_stage",
-                    bash_command=build_region_daily_platinum_command(stage_table, start_expr, end_expr),
+                    bash_command=build_region_daily_platinum_command(stage_table, platinum_start_expr, end_expr),
                 )
                 validate_stage_rows = build_validate_rows_task(
                     "validate_platinum_stage_rows",

--- a/airflow/tests/test_pipeline_builders_and_dataset_dags.py
+++ b/airflow/tests/test_pipeline_builders_and_dataset_dags.py
@@ -203,7 +203,9 @@ def test_dataset_dag_builders_include_expected_tasks_for_region_and_fuel(monkeyp
     assert "spark_platinum_stage" not in incremental_fuel.task_dict
     assert "spark_silver_batch" in incremental_power.task_dict
     assert "spark_curated_gold_batch" in incremental_power.task_dict
+    assert incremental_region.get_task("ingest_to_kafka").bash_command.endswith("--start {{ data_interval_start.in_timezone('UTC').strftime('%Y-%m-%dT%H') }} --end {{ data_interval_end.in_timezone('UTC').strftime('%Y-%m-%dT%H') }} --page-size 5000 --max-pages 20")
     assert incremental_region.get_task("spark_curated_gold_batch").downstream_task_ids == {"spark_platinum_stage"}
+    assert '--start "{{ data_interval_start.in_timezone(\'UTC\').replace(hour=0, minute=0, second=0, microsecond=0).isoformat() }}" --end "{{ data_interval_end.in_timezone(\'UTC\').isoformat() }}"' in incremental_region.get_task("spark_platinum_stage").bash_command
     assert incremental_region.get_task("spark_bronze_batch").pool == "electricity_region_data_bronze_write"
     assert incremental_fuel.get_task("spark_bronze_batch").pool == "electricity_fuel_type_data_bronze_write"
     assert "gold_power_operations_monthly.py" in incremental_power.get_task("spark_curated_gold_batch").bash_command

--- a/ingestion/src/dataset_registry.yml
+++ b/ingestion/src/dataset_registry.yml
@@ -3,6 +3,7 @@ datasets:
     route: electricity/rto/region-data
     topic: eia_electricity_region_data
     frequency: hourly
+    hourly_window_mode: current_day_end
     incremental_schedule: "@hourly"
     data_columns:
       - value

--- a/ingestion/src/eia_api.py
+++ b/ingestion/src/eia_api.py
@@ -41,7 +41,13 @@ def _subtarct_months(value: datetime, months: int) -> datetime:
         year -= 1
     return value.replace(year=year, month=month)
 
-def resolve_api_window_bounds(start: str, end: str, frequency: str = "hourly") -> tuple[str, str]:
+def resolve_api_window_bounds(
+    start: str,
+    end: str,
+    frequency: str = "hourly",
+    *,
+    hourly_window_mode: str = "interval",
+) -> tuple[str, str]:
     """Translate the pipeline's [start, end) window into EIA API parameters."""
 
     start_dt = _parse_cli_timestamp(start)
@@ -50,7 +56,10 @@ def resolve_api_window_bounds(start: str, end: str, frequency: str = "hourly") -
         raise ValueError(f"Invalid source window: end must be greater than start (start={start}, end={end})")
 
     if frequency == "hourly":
-        api_end = end_dt - timedelta(hours=1)
+        if hourly_window_mode == "current_day_end":
+            api_end = start_dt.replace(hour=23, minute=0, second=0, microsecond=0)
+        else:
+            api_end = end_dt - timedelta(hours=1)
         return start_dt.strftime("%Y-%m-%dT%H"), api_end.strftime("%Y-%m-%dT%H")
     if frequency == "monthly":
         api_start = start_dt - timedelta(days=1)
@@ -145,7 +154,12 @@ def fetch_dataset_rows(
 
     route = dataset_config["route"]
     query_url = f"{EIA_API_BASE_URL}/{route}/data/"
-    api_start, api_end = resolve_api_window_bounds(start, end, dataset_config.get("frequency", "hourly"))
+    api_start, api_end = resolve_api_window_bounds(
+        start,
+        end,
+        dataset_config.get("frequency", "hourly"),
+        hourly_window_mode=dataset_config.get("hourly_window_mode", "interval"),
+    )
     offset = 0
     all_rows: list[dict[str, Any]] = []
     page_count = 0

--- a/ingestion/src/registry.py
+++ b/ingestion/src/registry.py
@@ -13,6 +13,7 @@ from typing import Any
 import yaml
 
 SUPPORTED_BACKFILL_STEPS = {"hour", "day", "month", "year"}
+SUPPORTED_HOURLY_WINDOW_MODES = {"interval", "current_day_end"}
 
 
 def load_dataset_registry(path: Path) -> dict[str, dict[str, Any]]:
@@ -75,4 +76,11 @@ def validate_dataset_registry(registry: dict[str, dict[str, Any]]) -> None:
             supported_steps = ", ".join(sorted(SUPPORTED_BACKFILL_STEPS))
             raise ValueError(
                 f"Dataset '{dataset_id}' uses unsupported backfill step '{step}'. Supported: {supported_steps}"
+            )
+
+        hourly_window_mode = dataset.get("hourly_window_mode")
+        if hourly_window_mode and hourly_window_mode not in SUPPORTED_HOURLY_WINDOW_MODES:
+            supported_modes = ", ".join(sorted(SUPPORTED_HOURLY_WINDOW_MODES))
+            raise ValueError(
+                f"Dataset '{dataset_id}' uses unsupported hourly window mode '{hourly_window_mode}'. Supported: {supported_modes}"
             )

--- a/ingestion/tests/test_fetch_eia.py
+++ b/ingestion/tests/test_fetch_eia.py
@@ -69,6 +69,14 @@ def test_resolve_api_window_bounds_converts_exclusive_hourly_end() -> None:
     assert resolve_api_window_bounds("2026-03-15T14", "2026-03-15T15") == ("2026-03-15T14", "2026-03-15T14")
 
 
+def test_resolve_api_window_bounds_extends_current_day_end_for_region_forecast() -> None:
+    assert resolve_api_window_bounds(
+        "2026-03-17T03",
+        "2026-03-17T04",
+        hourly_window_mode="current_day_end",
+    ) == ("2026-03-17T03", "2026-03-17T23")
+
+
 def test_resolve_api_window_bounds_converts_monthly_window() -> None:
     assert resolve_api_window_bounds("2026-02-01T00:00:00+00:00", "2026-03-01T00:00:00+00:00", "monthly") == (
         "2026-01-31",

--- a/spark/common/io.py
+++ b/spark/common/io.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import time
 
 from pyspark.sql import DataFrame
+from pyspark.sql import Window
+from pyspark.sql import functions as F
 
 
 def path_exists(spark, path_str: str) -> bool:  # noqa: ANN001
@@ -123,6 +125,46 @@ def write_partitioned_parquet(df: DataFrame, output_path: str, partition_column:
         return
     (
         df.write.mode("overwrite")
+        .option("partitionOverwriteMode", "dynamic")
+        .partitionBy(partition_column)
+        .parquet(output_path)
+    )
+
+
+def merge_partitioned_parquet(
+    df: DataFrame,
+    output_path: str,
+    *,
+    merge_keys: list[str],
+    freshness_columns: list[str],
+    partition_column: str = "event_date",
+) -> None:
+    """Merge touched partitions with existing parquet rows before overwrite."""
+
+    if df.isEmpty():
+        return
+
+    spark = df.sparkSession
+    partition_values = [row[partition_column] for row in df.select(partition_column).dropna().distinct().collect()]
+    if not partition_values:
+        return
+
+    partition_paths = [f"{output_path.rstrip('/')}/{partition_column}={partition_value}" for partition_value in partition_values]
+    existing_paths = [path for path in partition_paths if path_exists(spark, path)]
+    combined_df = df
+    if existing_paths:
+        existing_df = spark.read.option("basePath", output_path).parquet(*existing_paths)
+        combined_df = existing_df.unionByName(df, allowMissingColumns=True)
+
+    ordering = [F.col(column_name).desc_nulls_last() for column_name in freshness_columns]
+    merge_window = Window.partitionBy(*merge_keys).orderBy(*ordering)
+    merged_df = (
+        combined_df.withColumn("_merge_rank", F.row_number().over(merge_window))
+        .filter(F.col("_merge_rank") == 1)
+        .drop("_merge_rank")
+    )
+    (
+        merged_df.write.mode("overwrite")
         .option("partitionOverwriteMode", "dynamic")
         .partitionBy(partition_column)
         .parquet(output_path)

--- a/spark/jobs/gold_region_fuel_serving_hourly.py
+++ b/spark/jobs/gold_region_fuel_serving_hourly.py
@@ -18,7 +18,7 @@ from pyspark.sql import functions as F
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from common.config import load_spark_app_config
-from common.io import has_partitioned_parquet_input, read_parquet_if_exists, read_partitioned_parquet, write_partitioned_parquet
+from common.io import has_partitioned_parquet_input, merge_partitioned_parquet, read_parquet_if_exists, read_partitioned_parquet
 from common.logging_utils import configure_logging, log_job_complete, log_job_start
 from common.quality import assert_no_nulls, assert_non_negative, assert_unique_keys
 from common.spark_session import build_spark_session
@@ -163,10 +163,16 @@ def build_fuel_type_hourly_generation(fuel_df: DataFrame) -> DataFrame:
     return gold_df
 
 
-def write_partitioned(df: DataFrame, output_path: str) -> None:
-    """Write a non-empty fact dataset partitioned by event date."""
+def write_partitioned(df: DataFrame, output_path: str, *, merge_keys: list[str]) -> None:
+    """Write a fact dataset while preserving earlier rows in touched day partitions."""
 
-    write_partitioned_parquet(df, output_path, partition_column="event_date")
+    merge_partitioned_parquet(
+        df,
+        output_path,
+        merge_keys=merge_keys,
+        freshness_columns=["loaded_at"],
+        partition_column="event_date",
+    )
 
 
 def build_respondent_dimension(spark, region_df: DataFrame | None, fuel_df: DataFrame | None, existing_path: str) -> DataFrame:  # noqa: ANN001
@@ -364,7 +370,7 @@ def main() -> None:
             )
             region_df = filter_time_window(region_df, "period", args.start, args.end)
             region_gold_df = build_region_hourly_metrics(region_df)
-            write_partitioned(region_gold_df, args.region_fact_path)
+            write_partitioned(region_gold_df, args.region_fact_path, merge_keys=["period", "respondent"])
         else:
             logger.info(
                 "Skipping Gold region fact build because no Silver input is available input_path=%s start=%s end=%s",
@@ -384,7 +390,7 @@ def main() -> None:
             )
             fuel_df = filter_time_window(fuel_df, "period", args.start, args.end)
             fuel_gold_df = build_fuel_type_hourly_generation(fuel_df)
-            write_partitioned(fuel_gold_df, args.fuel_fact_path)
+            write_partitioned(fuel_gold_df, args.fuel_fact_path, merge_keys=["period", "respondent", "fueltype"])
         else:
             logger.info(
                 "Skipping Gold fuel fact build because no Silver input is available input_path=%s start=%s end=%s",

--- a/spark/jobs/silver_clean_transform.py
+++ b/spark/jobs/silver_clean_transform.py
@@ -18,7 +18,7 @@ from pyspark.sql.functions import coalesce, col, count, countDistinct, current_t
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
 from common.config import load_spark_app_config
-from common.io import path_exists, write_partitioned_parquet
+from common.io import merge_partitioned_parquet, path_exists
 from common.logging_utils import configure_logging, log_job_complete, log_job_start
 from common.quality import assert_allowed_values, assert_no_conflicting_records, assert_no_nulls, assert_unique_keys
 from common.spark_session import build_spark_session
@@ -255,7 +255,13 @@ def validate_non_empty(raw_df: DataFrame, cleaned_df: DataFrame, dataset_id: str
 def write_partitioned_dataset(df: DataFrame, output_path: str) -> None:
     """Write a non-empty Silver dataset partitioned by event date."""
 
-    write_partitioned_parquet(df, output_path, partition_column="event_date")
+    merge_partitioned_parquet(
+        df,
+        output_path,
+        merge_keys=["event_id"],
+        freshness_columns=["loaded_at"],
+        partition_column="event_date",
+    )
 
 
 def main() -> None:

--- a/spark/tests/test_transforms.py
+++ b/spark/tests/test_transforms.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 
 import pytest
 
-from common.io import write_partitioned_parquet
+from common.io import merge_partitioned_parquet, write_partitioned_parquet
 from jobs.gold_region_fuel_serving_hourly import build_region_hourly_metrics, build_respondent_dimension
 from jobs.platinum_region_demand_daily import build_region_demand_daily
 from jobs.platinum_resource_planning_daily import build_resource_planning_daily
@@ -297,6 +297,112 @@ def test_write_partitioned_parquet_overwrites_only_touched_partitions(spark_sess
     assert rows[0]["metric"] == 100.0
     assert rows[1]["respondent"] == "MISO"
     assert rows[1]["metric"] == 250.0
+
+
+def test_merge_partitioned_parquet_preserves_same_day_rows_across_writes(spark_session, tmp_path) -> None:
+    output_path = tmp_path / "merged_silver_dataset"
+    first_df = spark_session.createDataFrame(
+        [
+            {
+                "event_id": "evt-1",
+                "period": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+                "respondent": "PJM",
+                "loaded_at": datetime(2026, 1, 1, 0, 10, tzinfo=timezone.utc),
+                "event_date": datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+            }
+        ]
+    )
+    second_df = spark_session.createDataFrame(
+        [
+            {
+                "event_id": "evt-2",
+                "period": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                "respondent": "PJM",
+                "loaded_at": datetime(2026, 1, 1, 1, 10, tzinfo=timezone.utc),
+                "event_date": datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+            }
+        ]
+    )
+
+    merge_partitioned_parquet(first_df, str(output_path), merge_keys=["event_id"], freshness_columns=["loaded_at"])
+    merge_partitioned_parquet(second_df, str(output_path), merge_keys=["event_id"], freshness_columns=["loaded_at"])
+
+    rows = spark_session.read.parquet(str(output_path)).orderBy("period").collect()
+
+    assert len(rows) == 2
+    assert [row["event_id"] for row in rows] == ["evt-1", "evt-2"]
+
+
+def test_merge_partitioned_parquet_preserves_earlier_gold_hours_when_later_hour_arrives(spark_session, tmp_path) -> None:
+    output_path = tmp_path / "merged_gold_dataset"
+    first_df = spark_session.createDataFrame(
+        [
+            {
+                "period": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+                "respondent": "PJM",
+                "actual_demand_mwh": 100.0,
+                "day_ahead_forecast_mwh": 95.0,
+                "loaded_at": datetime(2026, 1, 1, 0, 10, tzinfo=timezone.utc),
+                "event_date": datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+            }
+        ]
+    )
+    second_df = spark_session.createDataFrame(
+        [
+            {
+                "period": datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc),
+                "respondent": "PJM",
+                "actual_demand_mwh": 110.0,
+                "day_ahead_forecast_mwh": 100.0,
+                "loaded_at": datetime(2026, 1, 1, 1, 10, tzinfo=timezone.utc),
+                "event_date": datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+            }
+        ]
+    )
+
+    merge_partitioned_parquet(first_df, str(output_path), merge_keys=["period", "respondent"], freshness_columns=["loaded_at"])
+    merge_partitioned_parquet(second_df, str(output_path), merge_keys=["period", "respondent"], freshness_columns=["loaded_at"])
+
+    rows = spark_session.read.parquet(str(output_path)).orderBy("period").collect()
+
+    assert len(rows) == 2
+    assert [row["actual_demand_mwh"] for row in rows] == [100.0, 110.0]
+
+
+def test_merge_partitioned_parquet_replaces_same_gold_key_with_latest_loaded_at(spark_session, tmp_path) -> None:
+    output_path = tmp_path / "merged_gold_updates"
+    first_df = spark_session.createDataFrame(
+        [
+            {
+                "period": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+                "respondent": "PJM",
+                "actual_demand_mwh": 100.0,
+                "day_ahead_forecast_mwh": 95.0,
+                "loaded_at": datetime(2026, 1, 1, 0, 10, tzinfo=timezone.utc),
+                "event_date": datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+            }
+        ]
+    )
+    second_df = spark_session.createDataFrame(
+        [
+            {
+                "period": datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
+                "respondent": "PJM",
+                "actual_demand_mwh": 120.0,
+                "day_ahead_forecast_mwh": 98.0,
+                "loaded_at": datetime(2026, 1, 1, 0, 20, tzinfo=timezone.utc),
+                "event_date": datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+            }
+        ]
+    )
+
+    merge_partitioned_parquet(first_df, str(output_path), merge_keys=["period", "respondent"], freshness_columns=["loaded_at"])
+    merge_partitioned_parquet(second_df, str(output_path), merge_keys=["period", "respondent"], freshness_columns=["loaded_at"])
+
+    rows = spark_session.read.parquet(str(output_path)).collect()
+
+    assert len(rows) == 1
+    assert rows[0]["actual_demand_mwh"] == 120.0
 
 
 def test_region_demand_daily_aggregates_hourly_curated_gold_rows(spark_session) -> None:


### PR DESCRIPTION
## Summary
- extend electricity_region_data hourly ingestion so forecast pulls run through the end of the current UTC day
- preserve same-day silver and gold rows by merging touched event_date parquet partitions instead of replacing the entire partition on each hourly run
- make the region platinum incremental stage recompute from UTC day start through the current interval end
- add regression coverage for ingestion window translation, parquet partition merges, and the region DAG window wiring

## Validation
- pytest ingestion\\tests\\test_fetch_eia.py
- pytest airflow\\tests\\test_pipeline_builders_and_dataset_dags.py
- pytest spark\\tests\\test_transforms.py spark\\tests\\test_gold_platinum_cli.py

## Notes
- live replay/rebuild verified the current-day 2026-03-17 gold and platinum comparisons are back to ok
- the older 2026-03-16 admin mismatch is in the comparison path's timestamp filtering, not in the repaired parquet contents, so the admin logic was left unchanged per plan