### PR TITLE
Fix multi-day hourly backfill windowing

### DIFF
--- a/ingestion/src/eia_api.py
+++ b/ingestion/src/eia_api.py
@@ -56,10 +56,18 @@ def resolve_api_window_bounds(
         raise ValueError(f"Invalid source window: end must be greater than start (start={start}, end={end})")
 
     if frequency == "hourly":
+        last_included_hour = end_dt - timedelta(hours=1)
         if hourly_window_mode == "current_day_end":
-            api_end = start_dt.replace(hour=23, minute=0, second=0, microsecond=0)
+            # Region demand/forecast data often materializes for the full local
+            # operating day even when the pipeline asks for a single hour. Keep
+            # that behavior for same-day windows, but do not collapse multi-day
+            # backfill windows down to the start date.
+            if start_dt.date() == last_included_hour.date():
+                api_end = start_dt.replace(hour=23, minute=0, second=0, microsecond=0)
+            else:
+                api_end = last_included_hour
         else:
-            api_end = end_dt - timedelta(hours=1)
+            api_end = last_included_hour
         return start_dt.strftime("%Y-%m-%dT%H"), api_end.strftime("%Y-%m-%dT%H")
     if frequency == "monthly":
         api_start = start_dt - timedelta(days=1)

--- a/ingestion/tests/test_fetch_eia.py
+++ b/ingestion/tests/test_fetch_eia.py
@@ -77,6 +77,14 @@ def test_resolve_api_window_bounds_extends_current_day_end_for_region_forecast()
     ) == ("2026-03-17T03", "2026-03-17T23")
 
 
+def test_resolve_api_window_bounds_preserves_multi_day_current_day_end_backfill_window() -> None:
+    assert resolve_api_window_bounds(
+        "2026-03-09T00",
+        "2026-03-16T00",
+        hourly_window_mode="current_day_end",
+    ) == ("2026-03-09T00", "2026-03-15T23")
+
+
 def test_resolve_api_window_bounds_converts_monthly_window() -> None:
     assert resolve_api_window_bounds("2026-02-01T00:00:00+00:00", "2026-03-01T00:00:00+00:00", "monthly") == (
         "2026-01-31",


### PR DESCRIPTION
## Summary
- preserve full multi-day hourly backfill windows for datasets using current_day_end
- keep same-day current_day_end behavior for incremental region demand fetches
- add a regression test covering weekly backfill windows

## Testing
- pytest ingestion\\tests\\test_fetch_eia.py ingestion\\tests\\test_fetch_eia_cli.py
