### PR TITLE
Upgrade Resource Planning Lead page

### DIFF
--- a/app/pages/resource_planning_lead.py
+++ b/app/pages/resource_planning_lead.py
@@ -1,8 +1,8 @@
 """Resource Planning Lead dashboard.
 
 This page reads the planning serving table from Postgres through `data_access`,
-derives a ranked planning watchlist in pandas, and renders the comparison and
-trend views used for longer-horizon planning decisions.
+derives a ranked planning watchlist in pandas, and renders triage-first views
+for longer-horizon planning decisions.
 """
 
 from __future__ import annotations
@@ -19,8 +19,14 @@ from data_access import (
     load_resource_planning_daily,
     table_has_rows,
 )
+from planning_page_logic import (
+    build_planning_thresholds,
+    build_priority_history,
+    derive_planning_driver,
+    derive_planning_priority,
+)
 from respondent_geo import RESPONDENT_GEO
-from ui_utils import build_default_date_range, coerce_numeric, get_timezone_options, rank_priority_labels, safe_quantile
+from ui_utils import build_default_date_range, coerce_numeric, rank_priority_labels
 
 NUMERIC_COLUMNS = [
     "daily_demand_mwh",
@@ -37,59 +43,107 @@ NUMERIC_COLUMNS = [
 
 PRIORITY_ORDER = ["Critical", "Elevated", "Stable"]
 
+PRIORITY_COLORS = {
+    "Critical": "#E24B4A",
+    "Elevated": "#EF9F27",
+    "Stable": "#1D9E75",
+}
 
-def _derive_planning_priority(row: pd.Series, thresholds: dict[str, float | None]) -> str:
-    """Classify one respondent into the planning priority used on this page."""
+WATCHLIST_DISPLAY_COLUMNS = {
+    "respondent": "Respondent",
+    "respondent_name": "Name",
+    "planning_priority": "Priority",
+    "primary_driver": "Primary driver",
+    "carbon_intensity_kg_per_mwh": "Carbon intensity",
+    "renewable_share_pct": "Renewable share",
+    "peak_hour_gas_share_pct": "Peak-hour gas share",
+    "fuel_diversity_index": "Fuel diversity",
+    "avg_abs_forecast_error_pct": "Forecast error",
+    "clean_coverage_ratio": "Clean coverage ratio",
+}
 
-    carbon = pd.to_numeric(row.get("carbon_intensity_kg_per_mwh"), errors="coerce")
-    gas = pd.to_numeric(row.get("peak_hour_gas_share_pct"), errors="coerce")
-    renewable = pd.to_numeric(row.get("renewable_share_pct"), errors="coerce")
-    diversity = pd.to_numeric(row.get("fuel_diversity_index"), errors="coerce")
-    forecast = pd.to_numeric(row.get("avg_abs_forecast_error_pct"), errors="coerce")
 
-    critical = (
-        thresholds["carbon_p90"] is not None
-        and carbon >= thresholds["carbon_p90"]
-    ) or (
-        thresholds["gas_p90"] is not None
-        and gas >= thresholds["gas_p90"]
-        and thresholds["renewable_p10"] is not None
-        and renewable <= thresholds["renewable_p10"]
+def _color_priority(value: str) -> str:
+    color = PRIORITY_COLORS.get(value, "")
+    if not color:
+        return ""
+    return f"background-color: {color}; color: #ffffff"
+
+
+def _format_value(value: float | int | str | None, suffix: str = "", decimals: int = 1) -> str:
+    if value is None or pd.isna(value):
+        return "n/a"
+    if isinstance(value, str):
+        return value
+    return f"{value:.{decimals}f}{suffix}"
+
+
+def _describe_trend(values: pd.Series, lower_is_better: bool) -> str:
+    numeric = pd.to_numeric(values, errors="coerce").dropna()
+    if len(numeric) < 2:
+        return "Not enough history in the selected window."
+
+    start_value = float(numeric.iloc[0])
+    end_value = float(numeric.iloc[-1])
+    tolerance = max(float(numeric.std(ddof=0) or 0.0) * 0.25, abs(start_value) * 0.03, 0.5)
+    delta = end_value - start_value
+
+    if abs(delta) <= tolerance:
+        return "Flat across the selected window."
+
+    improving = delta < 0 if lower_is_better else delta > 0
+    return "Improving across the selected window." if improving else "Worsening across the selected window."
+
+
+def _plot_rank_chart(
+    container,
+    df: pd.DataFrame,
+    metric_column: str,
+    title: str,
+    x_label: str,
+    threshold_value: float | None,
+    empty_message: str,
+) -> None:
+    if df.empty:
+        container.info(empty_message)
+        return
+
+    fig = px.bar(
+        df,
+        x=metric_column,
+        y="respondent",
+        orientation="h",
+        color_discrete_sequence=["#185FA5"],
+        labels={metric_column: x_label, "respondent": ""},
+        title=title,
     )
-    if critical:
-        return "Critical"
-
-    elevated = (
-        thresholds["carbon_p75"] is not None
-        and carbon >= thresholds["carbon_p75"]
-    ) or (
-        thresholds["diversity_p25"] is not None
-        and diversity <= thresholds["diversity_p25"]
-    ) or (
-        thresholds["forecast_p75"] is not None
-        and forecast >= thresholds["forecast_p75"]
-    )
-    if elevated:
-        return "Elevated"
-    return "Stable"
+    if threshold_value is not None:
+        fig.add_vline(x=threshold_value, line_dash="dash", line_color="#E24B4A")
+    fig.update_layout(showlegend=False, margin=dict(l=0, r=0, t=45, b=0))
+    container.plotly_chart(fig, use_container_width=True)
 
 
-st.set_page_config(page_title="Resource Planning Lead", layout="wide")
-st.title("Resource Planning Lead")
-st.caption("Use this page to identify where structural planning attention is needed and which trend explains it.")
+st.set_page_config(
+    page_title="Resource Planning Lead",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
 
-with st.expander("How to read this page"):
-    st.markdown(
-        """
-- Start with the KPI row and planning watchlist to identify which respondents need structural attention.
-- Use the latest-date rankings to compare carbon intensity, renewable share, and peak-hour gas dependence.
-- Use focus trends to understand whether the issue is persistent or improving.
-- Supporting analysis is intentionally secondary to the watchlist.
-"""
-    )
+st.markdown(
+    """
+    <style>
+    [data-testid="stMetricValue"] { font-size: 1.4rem; font-weight: 600; }
+    [data-testid="stMetricLabel"] { font-size: 0.8rem; color: #666; }
+    div[data-testid="stExpander"] summary { font-weight: 600; }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
 
 if not table_has_rows("platinum.resource_planning_daily"):
-    st.warning("No planning mart rows found yet. Let the `platinum_resource_planning_daily` DAG run first.")
+    st.warning(
+        "No planning mart rows found yet. Let the `platinum_resource_planning_daily` DAG run first."
+    )
     st.stop()
 
 coverage = get_planning_coverage()
@@ -98,23 +152,50 @@ min_date = pd.to_datetime(coverage["min_date"])
 default_start_date, default_end_date = build_default_date_range(min_date, max_date, lookback_days=30)
 respondents = list_respondents("platinum.resource_planning_daily")
 
-col_a, col_b, col_c = st.columns([2, 2, 1])
-selected_range = col_a.date_input("Date range", value=(default_start_date, default_end_date), min_value=min_date.date(), max_value=max_date.date())
-selected_respondents = col_b.multiselect("Respondents", respondents, default=respondents)
-timezone_label = col_c.selectbox("Date label", get_timezone_options(), index=0)
+with st.sidebar:
+    st.title("Resource Planning Lead")
+    st.caption("Filter the dashboard below.")
+    st.divider()
+
+    selected_range = st.date_input(
+        "Date range",
+        value=(default_start_date, default_end_date),
+        min_value=min_date.date(),
+        max_value=max_date.date(),
+    )
+    selected_respondents = st.multiselect(
+        "Respondents",
+        respondents,
+        default=respondents,
+        help="Leave blank to include all respondents.",
+    )
+
+    st.divider()
+    with st.expander("How to read this page"):
+        st.markdown(
+            """
+- KPI strip - current planning pressure at a glance.
+- Watchlist - ranked list; Critical rows need structural attention now.
+- Where? - latest rankings showing which respondents stand out most.
+- Focus - drill into one respondent's planning trend.
+- Evidence - latest supporting table plus the historical priority mix.
+- Supporting analysis - secondary context and raw export.
+"""
+        )
 
 if len(selected_range) != 2:
+    st.info("Select a start and end date to load data.")
     st.stop()
 
-# Load the filtered warehouse slices first, then derive thresholds and rankings
-# locally so new teammates can trace how every chart is produced.
 start_date, end_date = selected_range
 filtered_respondents = selected_respondents or None
-planning_df = load_resource_planning_daily(str(start_date), str(end_date), filtered_respondents)
-latest_snapshot_df = load_latest_planning_snapshot(str(start_date), str(end_date), filtered_respondents)
-watchlist_df = load_planning_watchlist(str(start_date), str(end_date), filtered_respondents)
 
-if planning_df.empty or latest_snapshot_df.empty or watchlist_df.empty:
+with st.spinner("Loading resource planning data..."):
+    planning_df = load_resource_planning_daily(str(start_date), str(end_date), filtered_respondents)
+    latest_snapshot_df = load_latest_planning_snapshot(str(start_date), str(end_date), filtered_respondents)
+    watchlist_raw = load_planning_watchlist(str(start_date), str(end_date), filtered_respondents)
+
+if planning_df.empty or latest_snapshot_df.empty or watchlist_raw.empty:
     st.warning("No planning rows found for the selected filters.")
     st.stop()
 
@@ -125,113 +206,173 @@ planning_df["day_type"] = planning_df["weekend_flag"].map(lambda value: "Weekend
 latest_snapshot_df["date"] = pd.to_datetime(latest_snapshot_df["date"])
 latest_snapshot_df = coerce_numeric(latest_snapshot_df, NUMERIC_COLUMNS)
 
+watchlist_df = watchlist_raw.copy()
 watchlist_df["date"] = pd.to_datetime(watchlist_df["date"])
 watchlist_df = coerce_numeric(watchlist_df, NUMERIC_COLUMNS)
-thresholds = {
-    "carbon_p90": safe_quantile(watchlist_df["carbon_intensity_kg_per_mwh"], 0.9),
-    "gas_p90": safe_quantile(watchlist_df["peak_hour_gas_share_pct"], 0.9),
-    "renewable_p10": safe_quantile(watchlist_df["renewable_share_pct"], 0.1),
-    "carbon_p75": safe_quantile(watchlist_df["carbon_intensity_kg_per_mwh"], 0.75),
-    "diversity_p25": safe_quantile(watchlist_df["fuel_diversity_index"], 0.25),
-    "forecast_p75": safe_quantile(watchlist_df["avg_abs_forecast_error_pct"], 0.75),
-}
-watchlist_df["planning_priority"] = watchlist_df.apply(_derive_planning_priority, axis=1, thresholds=thresholds)
+
+thresholds = build_planning_thresholds(latest_snapshot_df)
+
+for df in (watchlist_df, latest_snapshot_df):
+    df["planning_priority"] = df.apply(derive_planning_priority, axis=1, thresholds=thresholds)
+    df["primary_driver"] = df.apply(derive_planning_driver, axis=1, thresholds=thresholds)
+
 watchlist_df = rank_priority_labels(watchlist_df, "planning_priority", PRIORITY_ORDER)
 watchlist_df = watchlist_df.sort_values(
-    ["planning_priority", "carbon_intensity_kg_per_mwh", "peak_hour_gas_share_pct", "renewable_share_pct"],
-    ascending=[True, False, False, True],
+    [
+        "planning_priority",
+        "carbon_intensity_kg_per_mwh",
+        "peak_hour_gas_share_pct",
+        "renewable_share_pct",
+        "respondent",
+    ],
+    ascending=[True, False, False, True, True],
     kind="stable",
-)
+).reset_index(drop=True)
+
+priority_history_df = build_priority_history(planning_df, thresholds)
 
 focus_options = watchlist_df["respondent"].dropna().tolist()
-focus_respondent = st.selectbox("Focus respondent", focus_options, index=0)
+focus_respondent = st.selectbox(
+    "Focus respondent",
+    options=focus_options,
+    index=0,
+    help="Select a respondent to inspect its planning trends.",
+)
 focus_df = planning_df[planning_df["respondent"] == focus_respondent].copy().sort_values("date")
+focus_snapshot_df = watchlist_df[watchlist_df["respondent"] == focus_respondent].head(1)
 
 latest_date = latest_snapshot_df["date"].max()
-metric1, metric2, metric3, metric4, metric5 = st.columns(5)
-# The KPI row gives a fast "what is the current planning picture?" summary.
-metric1.metric("Latest planning date", str(latest_date.date()))
-metric2.metric("Respondents in scope", f"{watchlist_df['respondent'].nunique():,}")
-metric3.metric("Highest carbon intensity", f"{watchlist_df['carbon_intensity_kg_per_mwh'].dropna().max():.1f}" if not watchlist_df["carbon_intensity_kg_per_mwh"].dropna().empty else "n/a")
-metric4.metric("Lowest renewable share", f"{watchlist_df['renewable_share_pct'].dropna().min():.1f}%" if not watchlist_df["renewable_share_pct"].dropna().empty else "n/a")
-metric5.metric("Highest peak-hour gas dependence", f"{watchlist_df['peak_hour_gas_share_pct'].dropna().max():.1f}%" if not watchlist_df["peak_hour_gas_share_pct"].dropna().empty else "n/a")
+n_respondents = watchlist_df["respondent"].nunique()
+n_critical = int((watchlist_df["planning_priority"] == "Critical").sum())
+n_elevated = int((watchlist_df["planning_priority"] == "Elevated").sum())
+highest_carbon = watchlist_df["carbon_intensity_kg_per_mwh"].dropna().max()
+lowest_renewable = watchlist_df["renewable_share_pct"].dropna().min()
 
-st.caption(f"Latest daily data shown through {latest_date.date()} | date label setting: `{timezone_label}`")
-
-st.subheader("What needs structural attention now?")
-st.caption("This watchlist is ranked from the latest planning snapshot using current-window quantile thresholds.")
-st.dataframe(
-    watchlist_df[
-        [
-            "respondent",
-            "respondent_name",
-            "daily_demand_mwh",
-            "renewable_share_pct",
-            "carbon_intensity_kg_per_mwh",
-            "fuel_diversity_index",
-            "peak_hour_gas_share_pct",
-            "avg_abs_forecast_error_pct",
-            "planning_priority",
-        ]
-    ],
-    use_container_width=True,
-    hide_index=True,
+st.title("Resource Planning Lead")
+st.caption(
+    f"Showing **{start_date}** -> **{end_date}** | "
+    f"**{n_respondents}** respondents | "
+    f"Latest loaded date: **{latest_date.date()}**"
 )
 
+k1, k2, k3, k4, k5 = st.columns(5)
+k1.metric("Respondents in scope", f"{n_respondents:,}")
+k2.metric("Critical priority", f"{n_critical:,}")
+k3.metric("Elevated priority", f"{n_elevated:,}")
+k4.metric("Highest carbon intensity", _format_value(highest_carbon))
+k5.metric("Lowest renewable share", _format_value(lowest_renewable, suffix="%"))
+
+st.divider()
+
+st.subheader("Watchlist - what needs structural attention now?")
+st.caption("Ranked Critical -> Elevated -> Stable. Primary driver explains why each row sits on the watchlist.")
+
+display_watchlist = watchlist_df[list(WATCHLIST_DISPLAY_COLUMNS.keys())].rename(columns=WATCHLIST_DISPLAY_COLUMNS)
+st.dataframe(
+    display_watchlist.style.applymap(_color_priority, subset=["Priority"]),
+    use_container_width=True,
+    hide_index=True,
+    height=min(40 + 35 * len(display_watchlist), 400),
+)
+
+st.divider()
+
 st.subheader("Where is structural attention needed?")
-st.caption("These latest-date rankings show which respondents stand out most on the key planning signals.")
-rank_col1, rank_col2, rank_col3 = st.columns(3)
+st.caption("Latest-snapshot rankings. Use these to decide which respondent should get planning attention first.")
 
-carbon_rank_df = latest_snapshot_df.dropna(subset=["carbon_intensity_kg_per_mwh"]).sort_values("carbon_intensity_kg_per_mwh", ascending=False).head(10)
-if carbon_rank_df.empty:
-    rank_col1.info("No carbon intensity rows are available at the latest date.")
+rank_col1, rank_col2 = st.columns(2)
+rank_col3, rank_col4 = st.columns(2)
+
+carbon_rank_df = (
+    latest_snapshot_df.dropna(subset=["carbon_intensity_kg_per_mwh"])
+    .sort_values("carbon_intensity_kg_per_mwh", ascending=False)
+    .head(10)
+    .sort_values("carbon_intensity_kg_per_mwh")
+)
+_plot_rank_chart(
+    rank_col1,
+    carbon_rank_df,
+    "carbon_intensity_kg_per_mwh",
+    "Highest carbon intensity",
+    "kg CO2e per MWh",
+    thresholds["carbon_p90"],
+    "No carbon intensity rows are available at the latest date.",
+)
+
+renewable_rank_df = (
+    latest_snapshot_df.dropna(subset=["renewable_share_pct"])
+    .sort_values("renewable_share_pct", ascending=True)
+    .head(10)
+    .sort_values("renewable_share_pct", ascending=False)
+)
+_plot_rank_chart(
+    rank_col2,
+    renewable_rank_df,
+    "renewable_share_pct",
+    "Lowest renewable share",
+    "Renewable share (%)",
+    thresholds["renewable_p10"],
+    "No renewable share rows are available at the latest date.",
+)
+
+gas_rank_df = (
+    latest_snapshot_df.dropna(subset=["peak_hour_gas_share_pct"])
+    .sort_values("peak_hour_gas_share_pct", ascending=False)
+    .head(10)
+    .sort_values("peak_hour_gas_share_pct")
+)
+_plot_rank_chart(
+    rank_col3,
+    gas_rank_df,
+    "peak_hour_gas_share_pct",
+    "Highest peak-hour gas dependence",
+    "Gas share at peak (%)",
+    thresholds["gas_p90"],
+    "No peak-hour gas rows are available at the latest date.",
+)
+
+diversity_rank_df = (
+    latest_snapshot_df.dropna(subset=["fuel_diversity_index"])
+    .sort_values("fuel_diversity_index", ascending=True)
+    .head(10)
+    .sort_values("fuel_diversity_index", ascending=False)
+)
+_plot_rank_chart(
+    rank_col4,
+    diversity_rank_df,
+    "fuel_diversity_index",
+    "Lowest fuel diversity",
+    "Fuel diversity index",
+    thresholds["diversity_p25"],
+    "No fuel diversity rows are available at the latest date.",
+)
+
+st.divider()
+
+st.subheader(f"Focus - {focus_respondent}")
+focus_driver = (
+    focus_snapshot_df["primary_driver"].iloc[0]
+    if not focus_snapshot_df.empty
+    else "Within expected range"
+)
+st.caption(
+    f"Current primary driver: **{focus_driver}**. "
+    "The charts below show whether this respondent is improving, flat, or worsening over the selected window."
+)
+
+focus_metric1, focus_metric2, focus_metric3, focus_metric4 = st.columns(4)
+if focus_snapshot_df.empty:
+    focus_metric1.metric("Priority", "n/a")
+    focus_metric2.metric("Carbon intensity", "n/a")
+    focus_metric3.metric("Renewable share", "n/a")
+    focus_metric4.metric("Clean coverage ratio", "n/a")
 else:
-    rank_col1.plotly_chart(
-        px.bar(
-            carbon_rank_df.sort_values("carbon_intensity_kg_per_mwh", ascending=True),
-            x="carbon_intensity_kg_per_mwh",
-            y="respondent",
-            orientation="h",
-            labels={"carbon_intensity_kg_per_mwh": "kg CO2e per MWh", "respondent": "Respondent"},
-            title="Highest carbon intensity",
-        ),
-        use_container_width=True,
-    )
+    focus_row = focus_snapshot_df.iloc[0]
+    focus_metric1.metric("Priority", str(focus_row["planning_priority"]))
+    focus_metric2.metric("Carbon intensity", _format_value(focus_row["carbon_intensity_kg_per_mwh"]))
+    focus_metric3.metric("Renewable share", _format_value(focus_row["renewable_share_pct"], suffix="%"))
+    focus_metric4.metric("Clean coverage ratio", _format_value(focus_row["clean_coverage_ratio"], decimals=2))
 
-renewable_rank_df = latest_snapshot_df.dropna(subset=["renewable_share_pct"]).sort_values("renewable_share_pct", ascending=True).head(10)
-if renewable_rank_df.empty:
-    rank_col2.info("No renewable share rows are available at the latest date.")
-else:
-    rank_col2.plotly_chart(
-        px.bar(
-            renewable_rank_df.sort_values("renewable_share_pct", ascending=False),
-            x="renewable_share_pct",
-            y="respondent",
-            orientation="h",
-            labels={"renewable_share_pct": "Renewable share (%)", "respondent": "Respondent"},
-            title="Lowest renewable share",
-        ),
-        use_container_width=True,
-    )
-
-gas_rank_df = latest_snapshot_df.dropna(subset=["peak_hour_gas_share_pct"]).sort_values("peak_hour_gas_share_pct", ascending=False).head(10)
-if gas_rank_df.empty:
-    rank_col3.info("No peak-hour gas rows are available at the latest date.")
-else:
-    rank_col3.plotly_chart(
-        px.bar(
-            gas_rank_df.sort_values("peak_hour_gas_share_pct", ascending=True),
-            x="peak_hour_gas_share_pct",
-            y="respondent",
-            orientation="h",
-            labels={"peak_hour_gas_share_pct": "Gas share at peak (%)", "respondent": "Respondent"},
-            title="Highest peak-hour gas dependence",
-        ),
-        use_container_width=True,
-    )
-
-st.subheader(f"What trend explains {focus_respondent}?")
-st.caption("These trends show whether the selected respondent is improving or drifting further onto the watchlist.")
 trend_col1, trend_col2 = st.columns(2)
 trend_col3, trend_col4 = st.columns(2)
 
@@ -245,10 +386,11 @@ else:
             x="date",
             y="carbon_intensity_kg_per_mwh",
             labels={"date": "Date", "carbon_intensity_kg_per_mwh": "kg CO2e per MWh"},
-            title="Is carbon intensity improving?",
+            title="Carbon intensity trend",
         ),
         use_container_width=True,
     )
+    trend_col1.caption(_describe_trend(carbon_df["carbon_intensity_kg_per_mwh"], lower_is_better=True))
 
 renewable_df = focus_df.dropna(subset=["renewable_share_pct"])
 if renewable_df.empty:
@@ -260,10 +402,11 @@ else:
             x="date",
             y="renewable_share_pct",
             labels={"date": "Date", "renewable_share_pct": "Renewable share (%)"},
-            title="Is renewable share improving?",
+            title="Renewable share trend",
         ),
         use_container_width=True,
     )
+    trend_col2.caption(_describe_trend(renewable_df["renewable_share_pct"], lower_is_better=False))
 
 gas_df = focus_df.dropna(subset=["peak_hour_gas_share_pct"])
 if gas_df.empty:
@@ -275,10 +418,11 @@ else:
             x="date",
             y="peak_hour_gas_share_pct",
             labels={"date": "Date", "peak_hour_gas_share_pct": "Gas share at peak (%)"},
-            title="Is peak-hour gas dependence rising?",
+            title="Peak-hour gas dependence trend",
         ),
         use_container_width=True,
     )
+    trend_col3.caption(_describe_trend(gas_df["peak_hour_gas_share_pct"], lower_is_better=True))
 
 forecast_df = focus_df.dropna(subset=["avg_abs_forecast_error_pct"])
 if forecast_df.empty:
@@ -290,33 +434,70 @@ else:
             x="date",
             y="avg_abs_forecast_error_pct",
             labels={"date": "Date", "avg_abs_forecast_error_pct": "Average absolute forecast error (%)"},
-            title="Is forecast accuracy worsening?",
+            title="Forecast error trend",
         ),
         use_container_width=True,
     )
+    trend_col4.caption(_describe_trend(forecast_df["avg_abs_forecast_error_pct"], lower_is_better=True))
 
-st.subheader("Comparative context at the latest date")
-st.caption("Use this table to sort respondents by the latest planning signals and validate the watchlist ordering.")
+st.divider()
+
+st.subheader("Planning evidence - what supports action?")
+st.caption("Filter the latest planning snapshot by priority and driver, then use the daily mix chart to see whether pressure is persistent.")
+
+evidence_filter1, evidence_filter2 = st.columns(2)
+priority_options = ["All"] + PRIORITY_ORDER
+driver_options = ["All"] + sorted(watchlist_df["primary_driver"].dropna().unique().tolist())
+selected_priority = evidence_filter1.selectbox("Priority filter", priority_options)
+selected_driver = evidence_filter2.selectbox("Primary driver filter", driver_options)
+
+evidence_df = watchlist_df.copy()
+if selected_priority != "All":
+    evidence_df = evidence_df[evidence_df["planning_priority"] == selected_priority]
+if selected_driver != "All":
+    evidence_df = evidence_df[evidence_df["primary_driver"] == selected_driver]
+
+display_evidence = evidence_df[list(WATCHLIST_DISPLAY_COLUMNS.keys())].rename(columns=WATCHLIST_DISPLAY_COLUMNS)
 st.dataframe(
-    latest_snapshot_df[
-        [
-            "respondent",
-            "renewable_share_pct",
-            "carbon_intensity_kg_per_mwh",
-            "fuel_diversity_index",
-            "peak_hour_gas_share_pct",
-            "clean_coverage_ratio",
-        ]
-    ].sort_values("carbon_intensity_kg_per_mwh", ascending=False),
+    display_evidence.style.applymap(_color_priority, subset=["Priority"]),
     use_container_width=True,
     hide_index=True,
+    height=min(40 + 35 * max(len(display_evidence), 1), 400),
 )
 
+if priority_history_df.empty:
+    st.info("No priority history is available for the selected window.")
+else:
+    fig_priority_mix = px.bar(
+        priority_history_df,
+        x="date",
+        y="respondent_count",
+        color="planning_priority",
+        barmode="stack",
+        color_discrete_map=PRIORITY_COLORS,
+        category_orders={"planning_priority": PRIORITY_ORDER},
+        labels={
+            "date": "Date",
+            "respondent_count": "Respondent count",
+            "planning_priority": "Priority",
+        },
+        title="Daily respondent counts by planning priority",
+    )
+    fig_priority_mix.update_layout(margin=dict(l=0, r=0, t=50, b=0))
+    st.plotly_chart(fig_priority_mix, use_container_width=True)
+
+st.divider()
+
 with st.expander("Supporting analysis", expanded=False):
-    # These views are supporting context after the watchlist and latest-date comparisons.
+    st.caption("Use these views as secondary context after the watchlist, rankings, and evidence sections are clear.")
+
     support_col1, support_col2 = st.columns(2)
 
-    drift_df = planning_df.dropna(subset=["daily_demand_mwh"]).groupby(["respondent", "day_type"], as_index=False)["daily_demand_mwh"].mean()
+    drift_df = (
+        planning_df.dropna(subset=["daily_demand_mwh"])
+        .groupby(["respondent", "day_type"], as_index=False)["daily_demand_mwh"]
+        .mean()
+    )
     if drift_df.empty:
         support_col1.info("No weekday versus weekend drift rows are available.")
     else:
@@ -332,6 +513,7 @@ with st.expander("Supporting analysis", expanded=False):
             ),
             use_container_width=True,
         )
+        support_col1.caption("Planning demand drift can help explain whether the current watchlist pressure is structural or calendar-driven.")
 
     map_df = latest_snapshot_df.copy()
     map_df["lat"] = map_df["respondent"].map(lambda code: RESPONDENT_GEO.get(code, {}).get("lat"))
@@ -349,13 +531,13 @@ with st.expander("Supporting analysis", expanded=False):
                 color="renewable_share_pct",
                 size="daily_demand_mwh",
                 hover_name="respondent",
-                hover_data={"carbon_intensity_kg_per_mwh": ':.1f', "location_label": True},
+                hover_data={"carbon_intensity_kg_per_mwh": ":.1f", "location_label": True},
                 scope="usa",
                 title="Approximate clean share map",
             ),
             use_container_width=True,
         )
-        support_col2.caption("Approximate respondent coordinates only; this map is supporting context.")
+        support_col2.caption("Approximate respondent coordinates only. Use this map as orientation, not as precise geospatial evidence.")
 
     raw_download_df = focus_df[
         [
@@ -368,6 +550,7 @@ with st.expander("Supporting analysis", expanded=False):
             "fuel_diversity_index",
             "peak_hour_gas_share_pct",
             "avg_abs_forecast_error_pct",
+            "clean_coverage_ratio",
         ]
     ].copy()
     st.download_button(

--- a/app/planning_page_logic.py
+++ b/app/planning_page_logic.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from ui_utils import safe_quantile
+
+PRIORITY_ORDER = ["Critical", "Elevated", "Stable"]
+
+
+def build_planning_thresholds(latest_snapshot_df: pd.DataFrame) -> dict[str, float | None]:
+    return {
+        "carbon_p90": safe_quantile(latest_snapshot_df.get("carbon_intensity_kg_per_mwh", pd.Series(dtype=float)), 0.9),
+        "gas_p90": safe_quantile(latest_snapshot_df.get("peak_hour_gas_share_pct", pd.Series(dtype=float)), 0.9),
+        "renewable_p10": safe_quantile(latest_snapshot_df.get("renewable_share_pct", pd.Series(dtype=float)), 0.1),
+        "carbon_p75": safe_quantile(latest_snapshot_df.get("carbon_intensity_kg_per_mwh", pd.Series(dtype=float)), 0.75),
+        "diversity_p25": safe_quantile(latest_snapshot_df.get("fuel_diversity_index", pd.Series(dtype=float)), 0.25),
+        "forecast_p75": safe_quantile(latest_snapshot_df.get("avg_abs_forecast_error_pct", pd.Series(dtype=float)), 0.75),
+    }
+
+
+def derive_planning_priority(row: pd.Series, thresholds: dict[str, float | None]) -> str:
+    carbon = pd.to_numeric(row.get("carbon_intensity_kg_per_mwh"), errors="coerce")
+    gas = pd.to_numeric(row.get("peak_hour_gas_share_pct"), errors="coerce")
+    renewable = pd.to_numeric(row.get("renewable_share_pct"), errors="coerce")
+    diversity = pd.to_numeric(row.get("fuel_diversity_index"), errors="coerce")
+    forecast = pd.to_numeric(row.get("avg_abs_forecast_error_pct"), errors="coerce")
+
+    critical = (
+        thresholds["carbon_p90"] is not None
+        and carbon >= thresholds["carbon_p90"]
+    ) or (
+        thresholds["gas_p90"] is not None
+        and gas >= thresholds["gas_p90"]
+        and thresholds["renewable_p10"] is not None
+        and renewable <= thresholds["renewable_p10"]
+    )
+    if critical:
+        return "Critical"
+
+    elevated = (
+        thresholds["carbon_p75"] is not None
+        and carbon >= thresholds["carbon_p75"]
+    ) or (
+        thresholds["diversity_p25"] is not None
+        and diversity <= thresholds["diversity_p25"]
+    ) or (
+        thresholds["forecast_p75"] is not None
+        and forecast >= thresholds["forecast_p75"]
+    )
+    if elevated:
+        return "Elevated"
+    return "Stable"
+
+
+def derive_planning_driver(row: pd.Series, thresholds: dict[str, float | None]) -> str:
+    carbon = pd.to_numeric(row.get("carbon_intensity_kg_per_mwh"), errors="coerce")
+    gas = pd.to_numeric(row.get("peak_hour_gas_share_pct"), errors="coerce")
+    renewable = pd.to_numeric(row.get("renewable_share_pct"), errors="coerce")
+    diversity = pd.to_numeric(row.get("fuel_diversity_index"), errors="coerce")
+    forecast = pd.to_numeric(row.get("avg_abs_forecast_error_pct"), errors="coerce")
+
+    if thresholds["carbon_p75"] is not None and carbon >= thresholds["carbon_p75"]:
+        return "High carbon intensity"
+    if (
+        thresholds["gas_p90"] is not None
+        and gas >= thresholds["gas_p90"]
+        and thresholds["renewable_p10"] is not None
+        and renewable <= thresholds["renewable_p10"]
+    ):
+        return "Gas-dependent peak with weak renewables"
+    if thresholds["diversity_p25"] is not None and diversity <= thresholds["diversity_p25"]:
+        return "Low fuel diversity"
+    if thresholds["forecast_p75"] is not None and forecast >= thresholds["forecast_p75"]:
+        return "Forecast accuracy drift"
+    return "Within expected range"
+
+
+def build_priority_history(planning_df: pd.DataFrame, thresholds: dict[str, float | None]) -> pd.DataFrame:
+    if planning_df.empty:
+        return pd.DataFrame(columns=["date", "planning_priority", "respondent_count"])
+
+    history_df = planning_df.copy()
+    history_df["date"] = pd.to_datetime(history_df["date"])
+    history_df["planning_priority"] = history_df.apply(derive_planning_priority, axis=1, thresholds=thresholds)
+
+    grouped_df = (
+        history_df.groupby(["date", "planning_priority"], as_index=False)["respondent"]
+        .nunique()
+        .rename(columns={"respondent": "respondent_count"})
+    )
+
+    all_dates = sorted(grouped_df["date"].dropna().unique().tolist())
+    full_index = pd.MultiIndex.from_product([all_dates, PRIORITY_ORDER], names=["date", "planning_priority"])
+
+    expanded_df = (
+        grouped_df.set_index(["date", "planning_priority"])
+        .reindex(full_index, fill_value=0)
+        .reset_index()
+    )
+    expanded_df["planning_priority"] = pd.Categorical(
+        expanded_df["planning_priority"],
+        categories=PRIORITY_ORDER,
+        ordered=True,
+    )
+    return expanded_df.sort_values(["date", "planning_priority"]).reset_index(drop=True)
+
+
+__all__ = [
+    "build_planning_thresholds",
+    "derive_planning_priority",
+    "derive_planning_driver",
+    "build_priority_history",
+]

--- a/app/tests/test_planning_page_logic.py
+++ b/app/tests/test_planning_page_logic.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import pandas as pd
+
+import planning_page_logic
+
+
+def test_build_planning_thresholds_returns_quantiles_and_handles_empty_values() -> None:
+    thresholds = planning_page_logic.build_planning_thresholds(
+        pd.DataFrame(
+            {
+                "carbon_intensity_kg_per_mwh": [100.0, 200.0, 300.0, 400.0],
+                "peak_hour_gas_share_pct": [10.0, 20.0, 30.0, 40.0],
+                "renewable_share_pct": [60.0, 50.0, 40.0, 30.0],
+                "fuel_diversity_index": [0.8, 0.7, 0.6, 0.5],
+                "avg_abs_forecast_error_pct": [1.0, 2.0, 3.0, 4.0],
+            }
+        )
+    )
+
+    assert thresholds == {
+        "carbon_p90": 370.0,
+        "gas_p90": 37.0,
+        "renewable_p10": 33.0,
+        "carbon_p75": 325.0,
+        "diversity_p25": 0.575,
+        "forecast_p75": 3.25,
+    }
+
+    empty_thresholds = planning_page_logic.build_planning_thresholds(pd.DataFrame())
+    assert empty_thresholds == {
+        "carbon_p90": None,
+        "gas_p90": None,
+        "renewable_p10": None,
+        "carbon_p75": None,
+        "diversity_p25": None,
+        "forecast_p75": None,
+    }
+
+
+def test_derive_planning_priority_covers_expected_branches() -> None:
+    thresholds = {
+        "carbon_p90": 300.0,
+        "gas_p90": 80.0,
+        "renewable_p10": 15.0,
+        "carbon_p75": 250.0,
+        "diversity_p25": 0.30,
+        "forecast_p75": 5.0,
+    }
+
+    assert (
+        planning_page_logic.derive_planning_priority(
+            pd.Series({"carbon_intensity_kg_per_mwh": 310.0}),
+            thresholds,
+        )
+        == "Critical"
+    )
+    assert (
+        planning_page_logic.derive_planning_priority(
+            pd.Series({"peak_hour_gas_share_pct": 90.0, "renewable_share_pct": 10.0}),
+            thresholds,
+        )
+        == "Critical"
+    )
+    assert (
+        planning_page_logic.derive_planning_priority(
+            pd.Series({"fuel_diversity_index": 0.20}),
+            thresholds,
+        )
+        == "Elevated"
+    )
+    assert (
+        planning_page_logic.derive_planning_priority(
+            pd.Series({"avg_abs_forecast_error_pct": 6.0}),
+            thresholds,
+        )
+        == "Elevated"
+    )
+    assert (
+        planning_page_logic.derive_planning_priority(
+            pd.Series(
+                {
+                    "carbon_intensity_kg_per_mwh": 120.0,
+                    "peak_hour_gas_share_pct": 35.0,
+                    "renewable_share_pct": 45.0,
+                    "fuel_diversity_index": 0.55,
+                    "avg_abs_forecast_error_pct": 2.0,
+                }
+            ),
+            thresholds,
+        )
+        == "Stable"
+    )
+
+
+def test_derive_planning_driver_uses_fixed_precedence() -> None:
+    thresholds = {
+        "carbon_p90": 300.0,
+        "gas_p90": 80.0,
+        "renewable_p10": 15.0,
+        "carbon_p75": 250.0,
+        "diversity_p25": 0.30,
+        "forecast_p75": 5.0,
+    }
+
+    row = pd.Series(
+        {
+            "carbon_intensity_kg_per_mwh": 275.0,
+            "peak_hour_gas_share_pct": 95.0,
+            "renewable_share_pct": 5.0,
+            "fuel_diversity_index": 0.20,
+            "avg_abs_forecast_error_pct": 8.0,
+        }
+    )
+    assert planning_page_logic.derive_planning_driver(row, thresholds) == "High carbon intensity"
+
+    assert (
+        planning_page_logic.derive_planning_driver(
+            pd.Series({"peak_hour_gas_share_pct": 90.0, "renewable_share_pct": 10.0}),
+            thresholds,
+        )
+        == "Gas-dependent peak with weak renewables"
+    )
+    assert (
+        planning_page_logic.derive_planning_driver(
+            pd.Series({"fuel_diversity_index": 0.20}),
+            thresholds,
+        )
+        == "Low fuel diversity"
+    )
+    assert (
+        planning_page_logic.derive_planning_driver(
+            pd.Series({"avg_abs_forecast_error_pct": 6.0}),
+            thresholds,
+        )
+        == "Forecast accuracy drift"
+    )
+    assert (
+        planning_page_logic.derive_planning_driver(
+            pd.Series({"avg_abs_forecast_error_pct": 2.0}),
+            thresholds,
+        )
+        == "Within expected range"
+    )
+
+
+def test_build_priority_history_uses_fixed_thresholds_for_daily_bucket_counts() -> None:
+    thresholds = {
+        "carbon_p90": 300.0,
+        "gas_p90": 80.0,
+        "renewable_p10": 15.0,
+        "carbon_p75": 250.0,
+        "diversity_p25": 0.30,
+        "forecast_p75": 5.0,
+    }
+    planning_df = pd.DataFrame(
+        [
+            {
+                "date": "2026-03-01",
+                "respondent": "A",
+                "carbon_intensity_kg_per_mwh": 320.0,
+                "peak_hour_gas_share_pct": 30.0,
+                "renewable_share_pct": 40.0,
+                "fuel_diversity_index": 0.70,
+                "avg_abs_forecast_error_pct": 2.0,
+            },
+            {
+                "date": "2026-03-01",
+                "respondent": "B",
+                "carbon_intensity_kg_per_mwh": 110.0,
+                "peak_hour_gas_share_pct": 90.0,
+                "renewable_share_pct": 10.0,
+                "fuel_diversity_index": 0.70,
+                "avg_abs_forecast_error_pct": 2.0,
+            },
+            {
+                "date": "2026-03-01",
+                "respondent": "C",
+                "carbon_intensity_kg_per_mwh": 120.0,
+                "peak_hour_gas_share_pct": 25.0,
+                "renewable_share_pct": 45.0,
+                "fuel_diversity_index": 0.20,
+                "avg_abs_forecast_error_pct": 2.0,
+            },
+            {
+                "date": "2026-03-02",
+                "respondent": "A",
+                "carbon_intensity_kg_per_mwh": 120.0,
+                "peak_hour_gas_share_pct": 20.0,
+                "renewable_share_pct": 55.0,
+                "fuel_diversity_index": 0.60,
+                "avg_abs_forecast_error_pct": 2.0,
+            },
+            {
+                "date": "2026-03-02",
+                "respondent": "B",
+                "carbon_intensity_kg_per_mwh": 330.0,
+                "peak_hour_gas_share_pct": 20.0,
+                "renewable_share_pct": 45.0,
+                "fuel_diversity_index": 0.60,
+                "avg_abs_forecast_error_pct": 2.0,
+            },
+            {
+                "date": "2026-03-02",
+                "respondent": "C",
+                "carbon_intensity_kg_per_mwh": 110.0,
+                "peak_hour_gas_share_pct": 20.0,
+                "renewable_share_pct": 45.0,
+                "fuel_diversity_index": 0.60,
+                "avg_abs_forecast_error_pct": 6.0,
+            },
+        ]
+    )
+
+    history_df = planning_page_logic.build_priority_history(planning_df, thresholds)
+
+    assert history_df.to_dict("records") == [
+        {"date": pd.Timestamp("2026-03-01"), "planning_priority": "Critical", "respondent_count": 2},
+        {"date": pd.Timestamp("2026-03-01"), "planning_priority": "Elevated", "respondent_count": 1},
+        {"date": pd.Timestamp("2026-03-01"), "planning_priority": "Stable", "respondent_count": 0},
+        {"date": pd.Timestamp("2026-03-02"), "planning_priority": "Critical", "respondent_count": 1},
+        {"date": pd.Timestamp("2026-03-02"), "planning_priority": "Elevated", "respondent_count": 1},
+        {"date": pd.Timestamp("2026-03-02"), "planning_priority": "Stable", "respondent_count": 1},
+    ]


### PR DESCRIPTION
## Summary
- rebuild the Resource Planning Lead Streamlit page to match the Grid Ops triage-first workflow
- add planning-specific helper logic for thresholds, priority classification, drivers, and fixed-threshold history
- add unit coverage for the new planning page logic

## Testing
- pytest app\\tests\\test_planning_page_logic.py app\\tests\\test_ui_utils.py app\\tests\\test_data_access.py app\\tests\\test_data_access_helpers.py
- python -m compileall app\\planning_page_logic.py app\\pages\\resource_planning_lead.py
