### PR TITLE
Centralize Streamlit Snowflake query caching

### DIFF
--- a/app/data_access_demand.py
+++ b/app/data_access_demand.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import pandas as pd
-import streamlit as st
 
 from data_access_shared import (
+    FAST_CACHE_TTL,
     AGG_DAILY_DEMAND_PEAK,
     FACT_DEMAND_HOURLY,
     _safe_read_sql,
@@ -14,7 +14,6 @@ from data_access_shared import (
 )
 
 
-@st.cache_data(ttl=60)
 def load_demand_hourly(
     start_ts: str | None = None,
     end_ts: str | None = None,
@@ -28,10 +27,9 @@ def load_demand_hourly(
     if ba_codes:
         query += f" and ba_code in ({sql_in_list(ba_codes)})"
     query += " order by period_ts, ba_code"
-    return _safe_read_sql(query)
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL)
 
 
-@st.cache_data(ttl=60)
 def load_daily_demand_peak(
     start_date: str | None = None,
     end_date: str | None = None,
@@ -45,10 +43,9 @@ def load_daily_demand_peak(
     if ba_codes:
         query += f" and ba_code in ({sql_in_list(ba_codes)})"
     query += " order by report_date, ba_code"
-    return _safe_read_sql(query)
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL)
 
 
-@st.cache_data(ttl=60)
 def load_latest_demand_snapshot(
     start_ts: str | None = None,
     end_ts: str | None = None,
@@ -78,4 +75,4 @@ def load_latest_demand_snapshot(
     join latest on f.period_ts = latest.period_ts
     order by f.ba_code
     """
-    return _safe_read_sql(query)
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL)

--- a/app/data_access_generation.py
+++ b/app/data_access_generation.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import pandas as pd
-import streamlit as st
 
 from data_access_shared import (
+    FAST_CACHE_TTL,
     AGG_DAILY_GENERATION,
     FACT_GENERATION_HOURLY,
     _safe_read_sql,
@@ -14,7 +14,6 @@ from data_access_shared import (
 )
 
 
-@st.cache_data(ttl=60)
 def load_generation_hourly(
     start_ts: str | None = None,
     end_ts: str | None = None,
@@ -31,10 +30,9 @@ def load_generation_hourly(
     if fuel_codes:
         query += f" and fuel_code in ({sql_in_list(fuel_codes)})"
     query += " order by period_ts, ba_code, fuel_code"
-    return _safe_read_sql(query)
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL)
 
 
-@st.cache_data(ttl=60)
 def load_daily_generation(
     start_date: str | None = None,
     end_date: str | None = None,
@@ -48,10 +46,9 @@ def load_daily_generation(
     if fuel_codes:
         query += f" and fuel_code in ({sql_in_list(fuel_codes)})"
     query += " order by report_date, fuel_code"
-    return _safe_read_sql(query)
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL)
 
 
-@st.cache_data(ttl=60)
 def load_latest_generation_snapshot(
     start_ts: str | None = None,
     end_ts: str | None = None,
@@ -88,4 +85,4 @@ def load_latest_generation_snapshot(
     group by f.ba_code, f.ba_name, f.period_ts
     order by total_gwh desc
     """
-    return _safe_read_sql(query)
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL)

--- a/app/data_access_operational.py
+++ b/app/data_access_operational.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import pandas as pd
-import streamlit as st
 
-from data_access_shared import SILVER_ELECTRICITY_POWER_OPERATIONAL_DATA, _safe_read_sql, qualified_table, sql_in_list, sql_literal
+from data_access_shared import SLOW_CACHE_TTL, SILVER_ELECTRICITY_POWER_OPERATIONAL_DATA, _safe_read_sql, qualified_table, sql_in_list, sql_literal
 from data_access_summary import table_has_rows
 from data_access_sales import load_sales_data
 
@@ -25,7 +24,6 @@ def _coerce_operational_frame(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-@st.cache_data(ttl=300)
 def load_operational_data(
     start_date: str | None = None,
     end_date: str | None = None,
@@ -49,10 +47,9 @@ def load_operational_data(
     if states:
         query += f" and state_id in ({sql_in_list(states)})"
     query += " order by period, state_id, fuel_type_id"
-    return _coerce_operational_frame(_safe_read_sql(query))
+    return _coerce_operational_frame(_safe_read_sql(query, ttl=SLOW_CACHE_TTL))
 
 
-@st.cache_data(ttl=300)
 def load_fuel_mix_by_state(
     start_date: str | None = None,
     end_date: str | None = None,
@@ -92,7 +89,6 @@ def load_fuel_mix_by_state(
     return grouped
 
 
-@st.cache_data(ttl=300)
 def load_fuel_mix_price_joined(
     start_date: str | None = None,
     end_date: str | None = None,
@@ -114,6 +110,5 @@ def load_fuel_mix_price_joined(
     )
 
 
-@st.cache_data(ttl=300)
 def operational_table_has_rows() -> bool:
     return table_has_rows(OPERATIONAL_TABLE)

--- a/app/data_access_sales.py
+++ b/app/data_access_sales.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 import pandas as pd
-import streamlit as st
 
 from data_access_shared import (
     FACT_SALES_MONTHLY,
+    SLOW_CACHE_TTL,
     SILVER_ELECTRICITY_RETAIL_SALES,
     _safe_read_sql,
     qualified_table,
@@ -45,7 +45,6 @@ def _coerce_gold_frame(df: pd.DataFrame) -> pd.DataFrame:
     return df
 
 
-@st.cache_data(ttl=300)
 def load_sales_data(
     start_date: str | None = None,
     end_date: str | None = None,
@@ -75,10 +74,9 @@ def load_sales_data(
     if states:
         query += f" and state_id in ({sql_in_list(states)})"
     query += " order by period, state_id, sector_name"
-    return _coerce_sales_frame(_safe_read_sql(query))
+    return _coerce_sales_frame(_safe_read_sql(query, ttl=SLOW_CACHE_TTL))
 
 
-@st.cache_data(ttl=300)
 def load_sales_coverage() -> dict[str, Any]:
     query = f"""
     select
@@ -90,7 +88,7 @@ def load_sales_coverage() -> dict[str, Any]:
     from {SALES_TABLE}
     where sector_abbr != 'ALL'
     """
-    row = _safe_read_sql(query).iloc[0].to_dict()
+    row = _safe_read_sql(query, ttl=SLOW_CACHE_TTL).iloc[0].to_dict()
     if row.get("min_period") is not None:
         row["min_period"] = pd.to_datetime(row["min_period"])
     if row.get("max_period") is not None:
@@ -98,7 +96,6 @@ def load_sales_coverage() -> dict[str, Any]:
     return row
 
 
-@st.cache_data(ttl=300)
 def load_sales_gold(
     start_date: str | None = None,
     end_date: str | None = None,
@@ -115,28 +112,24 @@ def load_sales_gold(
     if states:
         query += f" and state_id in ({sql_in_list(states)})"
     query += " order by period, state_id, sector_name"
-    return _coerce_gold_frame(_safe_read_sql(query))
+    return _coerce_gold_frame(_safe_read_sql(query, ttl=SLOW_CACHE_TTL))
 
 
-@st.cache_data(ttl=300)
 def list_sales_states() -> list[str]:
     query = f"select distinct state_id from {SALES_TABLE} where sector_abbr != 'ALL' order by state_id"
-    df = _safe_read_sql(query)
+    df = _safe_read_sql(query, ttl=SLOW_CACHE_TTL)
     return df["state_id"].dropna().tolist()
 
 
-@st.cache_data(ttl=300)
 def list_sales_sectors() -> list[str]:
     query = f"select distinct sector_name from {SALES_TABLE} where sector_abbr != 'ALL' order by sector_name"
-    df = _safe_read_sql(query)
+    df = _safe_read_sql(query, ttl=SLOW_CACHE_TTL)
     return df["sector_name"].dropna().tolist()
 
 
-@st.cache_data(ttl=300)
 def sales_table_has_rows() -> bool:
     return table_has_rows(SALES_TABLE)
 
 
-@st.cache_data(ttl=300)
 def gold_table_has_rows() -> bool:
     return table_has_rows(MONTHLY_GOLD_TABLE)

--- a/app/data_access_shared.py
+++ b/app/data_access_shared.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pandas as pd
 import snowflake.connector
+import streamlit as st
 
 from pipeline.core.settings import load_app_snowflake_settings
 
@@ -16,10 +17,17 @@ DIM_FUEL_TYPE = "DIM_FUEL_TYPE"
 SILVER_ELECTRICITY_RETAIL_SALES = "SILVER_ELECTRICITY_RETAIL_SALES"
 SILVER_ELECTRICITY_POWER_OPERATIONAL_DATA = "SILVER_ELECTRICITY_POWER_OPERATIONAL_DATA"
 FACT_SALES_MONTHLY = "FACT_SALES_MONTHLY"
+FAST_CACHE_TTL = 60
+SLOW_CACHE_TTL = 300
+
+
+@st.cache_resource
+def get_app_snowflake_settings():
+    return load_app_snowflake_settings()
 
 
 def _connection_kwargs() -> dict[str, object]:
-    settings = load_app_snowflake_settings()
+    settings = get_app_snowflake_settings()
     return {
         "account": settings.account,
         "user": settings.user,
@@ -35,13 +43,37 @@ def get_connection():
     return snowflake.connector.connect(**_connection_kwargs())
 
 
-def _safe_read_sql(query: str) -> pd.DataFrame:
+def _run_sql(query: str) -> pd.DataFrame:
     with get_connection() as conn:
         with conn.cursor() as cur:
             cur.execute(query)
             frame = cur.fetch_pandas_all()
             frame.columns = [column.lower() for column in frame.columns]
             return frame
+
+
+@st.cache_data(ttl=FAST_CACHE_TTL, show_spinner=False)
+def _safe_read_sql_fast_cached(query: str) -> pd.DataFrame:
+    return _run_sql(query)
+
+
+@st.cache_data(ttl=SLOW_CACHE_TTL, show_spinner=False)
+def _safe_read_sql_slow_cached(query: str) -> pd.DataFrame:
+    return _run_sql(query)
+
+
+def _safe_read_sql(query: str, ttl: int = FAST_CACHE_TTL) -> pd.DataFrame:
+    if ttl >= SLOW_CACHE_TTL:
+        return _safe_read_sql_slow_cached(query)
+    return _safe_read_sql_fast_cached(query)
+
+
+@st.cache_data(ttl=FAST_CACHE_TTL, show_spinner=False)
+def get_connection_status() -> tuple[bool, object]:
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("select current_timestamp()")
+            return True, cur.fetchone()[0]
 
 
 def sql_literal(value: str) -> str:

--- a/app/data_access_summary.py
+++ b/app/data_access_summary.py
@@ -2,21 +2,19 @@
 
 from __future__ import annotations
 
-from contextlib import closing
 from typing import Any
-
-import streamlit as st
 
 from data_access_shared import (
     AGG_DAILY_GENERATION,
     DIM_FUEL_TYPE,
+    FAST_CACHE_TTL,
     FACT_DEMAND_HOURLY,
     FACT_GENERATION_HOURLY,
     FACT_SALES_MONTHLY,
+    SLOW_CACHE_TTL,
     SILVER_ELECTRICITY_RETAIL_SALES,
     _safe_read_sql,
     qualified_table,
-    get_connection,
 )
 
 MONTHLY_SALES_TABLE = qualified_table("SILVER", SILVER_ELECTRICITY_RETAIL_SALES)
@@ -28,19 +26,15 @@ RAW_OPERATIONAL_TABLE = qualified_table("RAW", "ELECTRICITY_POWER_OPERATIONAL_RA
 META_PIPELINE_STATE = qualified_table("META", "PIPELINE_RUN_STATE")
 
 
-@st.cache_data(ttl=60)
 def table_has_rows(table_name: str = FACT_GENERATION_HOURLY) -> bool:
     query = f"select exists (select 1 from {table_name} limit 1)"
     try:
-        with get_connection() as conn:
-            with closing(conn.cursor()) as cur:
-                cur.execute(query)
-                return bool(cur.fetchone()[0])
+        result = _safe_read_sql(query, ttl=FAST_CACHE_TTL)
+        return bool(result.iloc[0, 0])
     except Exception:
         return False
 
 
-@st.cache_data(ttl=60)
 def get_generation_coverage() -> dict[str, Any]:
     query = f"""
     select
@@ -51,10 +45,9 @@ def get_generation_coverage() -> dict[str, Any]:
         count(distinct fuel_code) as fuel_count
     from {FACT_GENERATION_HOURLY}
     """
-    return _safe_read_sql(query).iloc[0].to_dict()
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL).iloc[0].to_dict()
 
 
-@st.cache_data(ttl=60)
 def get_demand_coverage() -> dict[str, Any]:
     query = f"""
     select
@@ -64,10 +57,9 @@ def get_demand_coverage() -> dict[str, Any]:
         count(distinct ba_code) as ba_count
     from {FACT_DEMAND_HOURLY}
     """
-    return _safe_read_sql(query).iloc[0].to_dict()
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL).iloc[0].to_dict()
 
 
-@st.cache_data(ttl=60)
 def get_daily_generation_coverage() -> dict[str, Any]:
     query = f"""
     select
@@ -76,10 +68,9 @@ def get_daily_generation_coverage() -> dict[str, Any]:
         count(*) as row_count
     from {AGG_DAILY_GENERATION}
     """
-    return _safe_read_sql(query).iloc[0].to_dict()
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL).iloc[0].to_dict()
 
 
-@st.cache_data(ttl=60)
 def get_monthly_sales_coverage() -> dict[str, Any]:
     query = f"""
     select
@@ -91,10 +82,9 @@ def get_monthly_sales_coverage() -> dict[str, Any]:
     from {MONTHLY_SALES_TABLE}
     where sector_abbr != 'ALL'
     """
-    return _safe_read_sql(query).iloc[0].to_dict()
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL).iloc[0].to_dict()
 
 
-@st.cache_data(ttl=60)
 def get_pipeline_state_summary() -> list[dict[str, Any]]:
     query = f"""
     select
@@ -109,10 +99,9 @@ def get_pipeline_state_summary() -> list[dict[str, Any]]:
     from {META_PIPELINE_STATE}
     order by dataset_id
     """
-    return _safe_read_sql(query).to_dict("records")
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL).to_dict("records")
 
 
-@st.cache_data(ttl=60)
 def get_raw_coverage_summary() -> list[dict[str, Any]]:
     query = f"""
     select 'electricity_generation_hourly' as dataset_id, min(try_to_date(substr(period, 1, 10))) as min_partition, max(try_to_date(substr(period, 1, 10))) as max_partition, count(*) as row_count from {RAW_GENERATION_TABLE}
@@ -124,10 +113,9 @@ def get_raw_coverage_summary() -> list[dict[str, Any]]:
     select 'electricity_power_operational_data_monthly' as dataset_id, min(to_date(period || '-01')) as min_partition, max(to_date(period || '-01')) as max_partition, count(*) as row_count from {RAW_OPERATIONAL_TABLE}
     order by dataset_id
     """
-    return _safe_read_sql(query).to_dict("records")
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL).to_dict("records")
 
 
-@st.cache_data(ttl=60)
 def get_gold_coverage_summary() -> list[dict[str, Any]]:
     query = f"""
     select 'fact_generation_hourly' as table_name, min(partition_date) as min_partition, max(partition_date) as max_partition, count(*) as row_count from {FACT_GENERATION_HOURLY}
@@ -139,10 +127,9 @@ def get_gold_coverage_summary() -> list[dict[str, Any]]:
     select 'fact_sales_monthly' as table_name, min(partition_date) as min_partition, max(partition_date) as max_partition, count(*) as row_count from {MONTHLY_GOLD_TABLE}
     order by table_name
     """
-    return _safe_read_sql(query).to_dict("records")
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL).to_dict("records")
 
 
-@st.cache_data(ttl=60)
 def get_generation_zero_value_summary(limit: int = 14) -> list[dict[str, Any]]:
     query = f"""
     select
@@ -157,18 +144,16 @@ def get_generation_zero_value_summary(limit: int = 14) -> list[dict[str, Any]]:
     order by report_date desc, fuel_code
     limit {int(limit)}
     """
-    return _safe_read_sql(query).to_dict("records")
+    return _safe_read_sql(query, ttl=FAST_CACHE_TTL).to_dict("records")
 
 
-@st.cache_data(ttl=60)
 def list_ba_codes(table_name: str = FACT_GENERATION_HOURLY) -> list[str]:
     query = f"select distinct ba_code from {table_name} order by ba_code"
-    df = _safe_read_sql(query)
+    df = _safe_read_sql(query, ttl=SLOW_CACHE_TTL)
     return df["ba_code"].dropna().tolist()
 
 
-@st.cache_data(ttl=60)
 def list_fuel_codes() -> list[str]:
     query = f"select fuel_code, fuel_name from {DIM_FUEL_TYPE} order by fuel_code"
-    df = _safe_read_sql(query)
+    df = _safe_read_sql(query, ttl=SLOW_CACHE_TTL)
     return df["fuel_code"].dropna().tolist()

--- a/app/streamlit_app.py
+++ b/app/streamlit_app.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import streamlit as st
 
 from data_access import (
-    get_connection,
+    get_connection_status,
     get_daily_generation_coverage,
     get_demand_coverage,
     get_generation_coverage,
@@ -50,10 +50,7 @@ for longer-horizon state and sector analysis.
 )
 
 try:
-    with get_connection() as conn:
-        with conn.cursor() as cur:
-            cur.execute("select current_timestamp()")
-            server_time = cur.fetchone()[0]
+    _, server_time = get_connection_status()
     st.success(f"Snowflake connected. Server time: {server_time}")
 except Exception as exc:
     st.error(f"Database connection failed: {exc}")


### PR DESCRIPTION
## Summary
- centralize Streamlit query caching in the shared Snowflake data access layer
- add shared fast and slow cache TTL policies plus cached connection status for the home page
- remove duplicated per-function cache decorators from app query modules

## Verification
- python -m compileall app