### PR TITLE
Add pipeline test coverage and pytest config

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+source = pipeline
+omit =
+    */__main__.py
+    */tests/*
+
+[report]
+skip_empty = True
+show_missing = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py
+pythonpath = .
+addopts = --cov=pipeline --cov-report=term-missing --cov-report=html --cov-report=json --cov-fail-under=70
+filterwarnings =
+    ignore::DeprecationWarning

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r airflow/requirements.txt
+-r pipeline/ingestion/requirements.txt
+coverage
+pytest-cov
+pandas

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,293 @@
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+def _install_snowflake_stubs() -> None:
+    if "snowflake.snowpark" in sys.modules:
+        return
+
+    snowflake_module = types.ModuleType("snowflake")
+    snowpark_module = types.ModuleType("snowflake.snowpark")
+    functions_module = types.ModuleType("snowflake.snowpark.functions")
+    types_module = types.ModuleType("snowflake.snowpark.types")
+
+    class Session:
+        class builder:
+            @staticmethod
+            def configs(_configs):
+                class _Builder:
+                    @staticmethod
+                    def create():
+                        return {"created": True}
+
+                return _Builder()
+
+    class _FakeWindowSpec:
+        def order_by(self, *columns):
+            return ("order_by", columns)
+
+    class Window:
+        @staticmethod
+        def partition_by(*columns):
+            return _FakeWindowSpec()
+
+    class _Type:
+        pass
+
+    class DoubleType(_Type):
+        pass
+
+    class LongType(_Type):
+        pass
+
+    class StringType(_Type):
+        pass
+
+    class StructField:
+        def __init__(self, name, datatype, nullable=True):
+            self.name = name
+            self.datatype = datatype
+            self.nullable = nullable
+
+    class StructType:
+        def __init__(self, fields):
+            self.fields = fields
+            self.names = [field.name for field in fields]
+
+    class _Expr:
+        def __init__(self, value):
+            self.value = value
+
+        def cast(self, cast_type):
+            return _Expr(("cast", self.value, cast_type))
+
+        def alias(self, alias_name):
+            return _Expr(("alias", self.value, alias_name))
+
+        def is_not_null(self):
+            return _Expr(("is_not_null", self.value))
+
+        def substr(self, start, length):
+            return _Expr(("substr", self.value, start, length))
+
+        def desc_nulls_last(self):
+            return _Expr(("desc_nulls_last", self.value))
+
+        def isin(self, values):
+            return _Expr(("isin", self.value, tuple(values)))
+
+        def otherwise(self, other):
+            return _Expr(("otherwise", self.value, other))
+
+        def __ge__(self, other):
+            return _Expr(("ge", self.value, other))
+
+        def __gt__(self, other):
+            return _Expr(("gt", self.value, other))
+
+        def __truediv__(self, other):
+            return _Expr(("div", self.value, other))
+
+        def __mul__(self, other):
+            return _Expr(("mul", self.value, other))
+
+        def __eq__(self, other):  # type: ignore[override]
+            return _Expr(("eq", self.value, other))
+
+        def __or__(self, other):
+            return _Expr(("or", self.value, getattr(other, "value", other)))
+
+        def __repr__(self):
+            return f"_Expr({self.value!r})"
+
+    def _expr(name):
+        def _inner(*args, **kwargs):
+            return _Expr((name, args, kwargs))
+
+        return _inner
+
+    for name in (
+        "col",
+        "concat",
+        "current_timestamp",
+        "lit",
+        "md5",
+        "row_number",
+        "to_date",
+        "to_timestamp",
+        "trim",
+        "upper",
+        "when",
+        "max",
+        "round",
+        "sum",
+    ):
+        setattr(functions_module, name, _expr(name))
+
+    snowpark_module.Session = Session
+    snowpark_module.Window = Window
+    types_module.DoubleType = DoubleType
+    types_module.LongType = LongType
+    types_module.StringType = StringType
+    types_module.StructField = StructField
+    types_module.StructType = StructType
+
+    sys.modules["snowflake"] = snowflake_module
+    sys.modules["snowflake.snowpark"] = snowpark_module
+    sys.modules["snowflake.snowpark.functions"] = functions_module
+    sys.modules["snowflake.snowpark.types"] = types_module
+
+
+_install_snowflake_stubs()
+
+
+class FakeRow(dict):
+    def as_dict(self):
+        return dict(self)
+
+
+class FakeQuery:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+
+    def collect(self):
+        return self.rows
+
+
+class FakeTable:
+    def __init__(self, session, name, schema_names=None):
+        self.session = session
+        self.name = name
+        self.schema = types.SimpleNamespace(names=list(schema_names or []))
+
+    def limit(self, _n):
+        return self
+
+    def collect(self):
+        return []
+
+
+class FakeSession:
+    def __init__(self):
+        self.sql_calls = []
+        self.sql_results = []
+        self.tables = {}
+        self.created = []
+        self.closed = False
+
+    def sql(self, query):
+        self.sql_calls.append(query)
+        rows = self.sql_results.pop(0) if self.sql_results else []
+        return FakeQuery(rows)
+
+    def table(self, name):
+        if name not in self.tables:
+            raise RuntimeError(f"Unknown table {name}")
+        value = self.tables[name]
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    def create_dataframe(self, rows, schema=None):
+        self.created.append((rows, schema))
+        return FakeDataFrame(rows, schema)
+
+    def close(self):
+        self.closed = True
+
+
+class FakeWriter:
+    def __init__(self):
+        self.calls = []
+
+    def mode(self, mode_name):
+        self.calls.append(("mode", mode_name))
+        return self
+
+    def save_as_table(self, table_name, **kwargs):
+        self.calls.append(("save_as_table", table_name, kwargs))
+
+
+class FakeDataFrame:
+    def __init__(self, rows=None, schema=None, count_value=None):
+        self.rows = rows or []
+        self.schema = schema or types.SimpleNamespace(names=[])
+        self.count_value = len(self.rows) if count_value is None else count_value
+        self.write = FakeWriter()
+        self.operations = []
+
+    def count(self):
+        return self.count_value
+
+    def with_column(self, name, value):
+        self.operations.append(("with_column", name, value))
+        names = list(getattr(self.schema, "names", []))
+        if name not in names:
+            names.append(name)
+        self.schema = types.SimpleNamespace(names=names)
+        return self
+
+    def with_column_renamed(self, old, new):
+        self.operations.append(("with_column_renamed", old, new))
+        return self
+
+    def filter(self, condition):
+        self.operations.append(("filter", condition))
+        return self
+
+    def select(self, *columns):
+        self.operations.append(("select", columns))
+        self.schema = types.SimpleNamespace(names=[str(column) for column in columns])
+        return self
+
+    def drop(self, *columns):
+        self.operations.append(("drop", columns))
+        return self
+
+    def dropna(self, subset=None):
+        self.operations.append(("dropna", tuple(subset or [])))
+        return self
+
+    def drop_duplicates(self, columns):
+        self.operations.append(("drop_duplicates", tuple(columns)))
+        return self
+
+    def group_by(self, *columns):
+        self.operations.append(("group_by", columns))
+        return FakeGroupedDataFrame(self)
+
+    def agg(self, *args, **kwargs):
+        self.operations.append(("agg", args, kwargs))
+        return self
+
+    def join(self, other, on=None, how=None):
+        self.operations.append(("join", on, how))
+        return self
+
+    def union(self, other):
+        self.operations.append(("union", other))
+        return self
+
+
+class FakeGroupedDataFrame:
+    def __init__(self, df):
+        self.df = df
+
+    def agg(self, *args, **kwargs):
+        self.df.operations.append(("agg", args, kwargs))
+        return self.df
+
+
+@pytest.fixture
+def fake_session():
+    return FakeSession()

--- a/tests/test_core_snowflake.py
+++ b/tests/test_core_snowflake.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from types import SimpleNamespace
+
+from pipeline.core import snowflake
+
+
+def test_get_snowpark_session_and_close_session(fake_session, monkeypatch) -> None:
+    created = {}
+
+    class Builder:
+        @staticmethod
+        def configs(config):
+            created["config"] = config
+
+            class Created:
+                @staticmethod
+                def create():
+                    return fake_session
+
+            return Created()
+
+    fake_session.close = lambda: created.setdefault("closed", True)
+    monkeypatch.setattr(snowflake.Session, "builder", Builder)
+
+    settings = SimpleNamespace(
+        account="acct",
+        user="user",
+        password="pw",
+        role="role",
+        warehouse="wh",
+        database="db",
+        schema="schema",
+    )
+    session = snowflake.get_snowpark_session(settings)
+    snowflake.close_session(session)
+
+    assert created["config"]["database"] == "db"
+    assert created["closed"] is True
+
+
+def test_normalizers_and_type_helpers() -> None:
+    assert snowflake.normalize_record_keys({"a-b": 1, "Two": 2}) == {"A_B": 1, "TWO": 2}
+    assert isinstance(snowflake._snowpark_type("double"), snowflake.DoubleType)
+    assert isinstance(snowflake._snowpark_type("int"), snowflake.LongType)
+    assert isinstance(snowflake._snowpark_type("text"), snowflake.StringType)
+    assert snowflake._coerce_raw_value("1.5", "double") == 1.5
+    assert snowflake._coerce_raw_value("7", "int") == 7
+    assert snowflake._coerce_raw_value(4, "string") == "4"
+    assert snowflake._coerce_raw_value(None, "string") is None
+
+
+def test_build_struct_and_write_raw_records(fake_session, monkeypatch) -> None:
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return datetime(2026, 4, 9, 10, 30)
+
+    monkeypatch.setattr(snowflake, "datetime", FixedDateTime)
+
+    struct = snowflake._build_raw_struct_type(["A_B", "COUNT"], {"a-b": "string", "COUNT": "int"})
+    assert struct.names == ["A_B", "COUNT"]
+
+    written = snowflake.write_raw_records(
+        fake_session,
+        "RAW.TABLE",
+        [{"a-b": "x", "count": "5"}],
+        {"a-b": "string", "count": "int"},
+    )
+
+    assert written == 1
+    rows, schema = fake_session.created[0]
+    assert rows[0][0] == "x"
+    assert rows[0][1] == 5
+    assert schema.names[-1] == "_INGESTED_AT"
+
+
+def test_rows_exist_and_table_checks_handle_success_and_failure(fake_session) -> None:
+    fake_session.sql_results = [[{"N": 2}], [{"N": 0}], RuntimeError("boom")]
+    assert snowflake.rows_exist_for_business_date(fake_session, "RAW.TABLE", "2026-04-09", frequency="hourly") is True
+    assert snowflake.table_has_rows_for_partition_date(fake_session, "RAW.TABLE", "2026-04-09") is False
+    assert snowflake.rows_exist_for_business_date(fake_session, "RAW.TABLE", "2026-04-01", frequency="monthly") is False
+
+
+def test_table_exists_and_sql_literal(fake_session) -> None:
+    fake_session.tables["DB.TABLE"] = SimpleNamespace(limit=lambda _n: SimpleNamespace(collect=lambda: []))
+    assert snowflake.table_exists(fake_session, "DB.TABLE") is True
+    assert snowflake.table_exists(fake_session, "MISSING.TABLE") is False
+    assert snowflake._sql_literal("O'Hare") == "'O''Hare'"
+    assert snowflake._sql_literal(None) == "NULL"
+
+
+def test_pipeline_state_helpers(fake_session, monkeypatch) -> None:
+    monkeypatch.setattr(snowflake, "ensure_pipeline_state_table", lambda session, database: "EIA_PIPELINE.META.PIPELINE_RUN_STATE")
+    fake_session.sql_results = [
+        [],
+        [SimpleNamespace(as_dict=lambda: {"DATASET_ID": "ds", "BOOTSTRAP_INGEST_COMPLETE": True})],
+    ]
+    default_state = snowflake.get_pipeline_state(fake_session, "EIA_PIPELINE", "ds")
+    loaded_state = snowflake.get_pipeline_state(fake_session, "EIA_PIPELINE", "ds")
+
+    assert default_state["dataset_id"] == "ds"
+    assert loaded_state["bootstrap_ingest_complete"] is True
+
+
+def test_ensure_pipeline_state_table_and_upserts_emit_sql(fake_session) -> None:
+    table_name = snowflake.ensure_pipeline_state_table(fake_session, "EIA_PIPELINE")
+    assert table_name == "EIA_PIPELINE.META.PIPELINE_RUN_STATE"
+    assert "CREATE TABLE IF NOT EXISTS" in fake_session.sql_calls[0]
+    assert any("ADD COLUMN IF NOT EXISTS dataset_id" in call for call in fake_session.sql_calls[1:])
+
+    fake_session.sql_calls.clear()
+    snowflake.upsert_pipeline_state(
+        fake_session,
+        "EIA_PIPELINE",
+        "ds",
+        frequency="hourly",
+        bootstrap_ingest_complete=True,
+        bootstrap_transform_complete=False,
+        last_raw_partition="2026-04-09",
+        last_silver_partition=None,
+        last_gold_partition=None,
+        last_ingest_started_at="2026-04-09T00:00:00",
+        last_ingest_succeeded_at=None,
+        last_transform_started_at=None,
+        last_transform_succeeded_at=None,
+        last_ingest_error_message=None,
+        last_transform_error_message="bad",
+    )
+    assert "MERGE INTO EIA_PIPELINE.META.PIPELINE_RUN_STATE" in fake_session.sql_calls[-1]
+
+
+def test_update_ingest_and_transform_state_reuse_prior_values(monkeypatch) -> None:
+    captured = []
+    prior_state = {
+        "bootstrap_transform_complete": True,
+        "bootstrap_ingest_complete": False,
+        "last_raw_partition": date(2026, 4, 1),
+        "last_silver_partition": date(2026, 4, 2),
+        "last_gold_partition": date(2026, 4, 3),
+        "last_transform_started_at": datetime(2026, 4, 4, 1, 0),
+        "last_transform_succeeded_at": datetime(2026, 4, 4, 2, 0),
+        "last_ingest_started_at": datetime(2026, 4, 5, 1, 0),
+        "last_ingest_succeeded_at": datetime(2026, 4, 5, 2, 0),
+        "last_transform_error_message": "old",
+        "last_ingest_error_message": "older",
+    }
+    monkeypatch.setattr(snowflake, "get_pipeline_state", lambda *args, **kwargs: dict(prior_state))
+    monkeypatch.setattr(snowflake, "upsert_pipeline_state", lambda *args, **kwargs: captured.append(kwargs))
+
+    snowflake.update_ingest_state(
+        None,
+        "EIA_PIPELINE",
+        "ds",
+        frequency="hourly",
+        bootstrap_ingest_complete=True,
+        last_raw_partition=None,
+        last_ingest_started_at="new_start",
+        last_ingest_succeeded_at="new_end",
+        last_ingest_error_message="err",
+    )
+    snowflake.update_transform_state(
+        None,
+        "EIA_PIPELINE",
+        "ds",
+        frequency="hourly",
+        bootstrap_transform_complete=False,
+        last_silver_partition=None,
+        last_gold_partition=None,
+        last_transform_started_at="ts1",
+        last_transform_succeeded_at="ts2",
+        last_transform_error_message="boom",
+    )
+
+    assert captured[0]["last_raw_partition"] == "2026-04-01"
+    assert captured[0]["last_transform_error_message"] == "old"
+    assert captured[1]["last_ingest_started_at"] == "2026-04-05T01:00:00"
+    assert captured[1]["last_transform_error_message"] == "boom"
+
+
+def test_partition_queries_and_result_normalization(fake_session, monkeypatch) -> None:
+    monkeypatch.setattr(snowflake, "table_exists", lambda *args, **kwargs: True)
+    monkeypatch.setattr(snowflake, "current_partition_for_frequency", lambda frequency: "2026-04-09")
+    fake_session.sql_results = [
+        [
+            {"PARTITION_DATE": date(2026, 4, 1), "PROCESSED_AT": datetime(2026, 4, 2, 3, 0), "ROW_COUNT": 5},
+        ],
+        [
+            {
+                "PARTITION_DATE": date(2026, 4, 1),
+                "PROCESSED_AT": datetime(2026, 4, 2, 3, 0),
+                "ROW_COUNT": 24,
+                "DISTINCT_PERIOD_COUNT": 24,
+            },
+            {
+                "PARTITION_DATE": date(2026, 4, 9),
+                "PROCESSED_AT": datetime(2026, 4, 9, 3, 0),
+                "ROW_COUNT": 4,
+                "DISTINCT_PERIOD_COUNT": 4,
+            },
+        ],
+        [
+            {"PARTITION_DATE": date(2026, 4, 1), "PROCESSED_AT": datetime(2026, 4, 2, 3, 0), "ROW_COUNT": 5},
+        ],
+    ]
+
+    status = snowflake.list_partition_status(
+        fake_session,
+        "DB.TABLE",
+        frequency="monthly",
+        processed_column="gold_processed_at",
+        start_date="2026-04-15",
+        end_date="2026-05-20",
+    )
+    raw = snowflake.raw_partitions_for_dataset(fake_session, "DB.RAW", frequency="hourly")
+    mapped = snowflake.pipeline_partitions_for_table(
+        fake_session,
+        "DB.SILVER",
+        frequency="hourly",
+        processed_column="silver_processed_at",
+    )
+
+    assert status[0]["partition_date"] == "2026-04-01"
+    assert raw[0]["is_complete"] is True
+    assert raw[1]["is_complete"] is True
+    assert mapped["2026-04-01"]["row_count"] == 5
+    assert snowflake.raw_partition_expression("monthly") == "TO_DATE(PERIOD || '-01')"
+    assert snowflake.current_partition_for_frequency("hourly")
+    assert snowflake._normalize_result_value(date(2026, 4, 1)) == "2026-04-01"
+    assert snowflake._normalize_result_value(None) is None

--- a/tests/test_core_windowing_settings.py
+++ b/tests/test_core_windowing_settings.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from pipeline.core import settings, windowing
+
+
+def test_normalize_optional_value_handles_none_and_text() -> None:
+    assert windowing._normalize_optional_value(None) == ""
+    assert windowing._normalize_optional_value(" none ") == ""
+    assert windowing._normalize_optional_value(" 2026-04-01 ") == "2026-04-01"
+
+
+def test_month_anchor_and_shift_partition_support_monthly_and_hourly() -> None:
+    assert windowing.month_anchor_date("2026-04-19") == "2026-04-01"
+    assert windowing.shift_partition("2026-04-19", "hourly", -2) == "2026-04-17"
+    assert windowing.shift_partition("2026-04-19", "monthly", 2) == "2026-06-01"
+
+
+def test_enumerate_partitions_for_hourly_and_monthly() -> None:
+    assert windowing.enumerate_partitions("2026-04-01", "2026-04-03", frequency="hourly") == [
+        "2026-04-01",
+        "2026-04-02",
+        "2026-04-03",
+    ]
+    assert windowing.enumerate_partitions("2026-01-15", "2026-03-20", frequency="monthly") == [
+        "2026-01-01",
+        "2026-02-01",
+        "2026-03-01",
+    ]
+
+
+def test_hourly_and_monthly_chunks_respect_bounds() -> None:
+    assert windowing._hourly_chunks("2026-04-01", "2026-04-03", 2) == [
+        ("2026-04-01T00", "2026-04-02T23"),
+        ("2026-04-03T00", "2026-04-03T23"),
+    ]
+    assert windowing._monthly_chunks("2026-01-01", "2026-03-01", 2) == [
+        ("2026-01", "2026-02"),
+        ("2026-03", "2026-03"),
+    ]
+
+
+def test_resolve_ingest_windows_uses_explicit_ranges_and_defaults(monkeypatch) -> None:
+    fixed_now = datetime(2026, 4, 9, 12, 0, tzinfo=timezone.utc)
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now
+
+    monkeypatch.setattr(windowing, "datetime", FixedDateTime)
+
+    hourly_dataset = {"frequency": "hourly", "chunk_days": 2}
+    monthly_dataset = {"frequency": "monthly", "chunk_months": 2, "rolling_months": 3}
+
+    assert windowing.resolve_ingest_windows(hourly_dataset, start_date="2026-04-01", end_date="2026-04-03") == [
+        ("2026-04-01T00", "2026-04-02T23"),
+        ("2026-04-03T00", "2026-04-03T23"),
+    ]
+    assert windowing.resolve_ingest_windows(monthly_dataset) == [("2026-02", "2026-04")]
+    assert windowing.resolve_ingest_windows({"frequency": "hourly"}, rolling_hours="6") == [
+        ("2026-04-09T06", "2026-04-09T12")
+    ]
+
+
+def test_processing_and_business_dates_normalize_monthly() -> None:
+    assert windowing.resolve_processing_date({"date": " 2026-04-09 "}, "2026-04-08") == "2026-04-09"
+    assert windowing.resolve_processing_date(None, "2026-04-08") == "2026-04-08"
+    assert windowing.resolve_business_date({"date": "2026-04-19"}, "2026-04-08", frequency="monthly") == "2026-04-01"
+    assert windowing.resolve_business_date(None, "2026-04-08", frequency="hourly") == "2026-04-08"
+
+
+def test_read_optional_float_and_load_settings(monkeypatch) -> None:
+    monkeypatch.setenv("ROLLING_HOURS", " 6.5 ")
+    monkeypatch.setenv("EIA_API_KEY", "abc")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acct")
+    monkeypatch.setenv("SNOWFLAKE_USER", "user")
+    monkeypatch.setenv("SNOWFLAKE_PASSWORD", "pw")
+    monkeypatch.setenv("SNOWFLAKE_APP_SCHEMA", "APP_GOLD")
+
+    assert settings._read_optional_float("ROLLING_HOURS", 2.0) == 6.5
+    assert settings.load_eia_settings().default_rolling_hours == 6.5
+
+    snowflake_settings = settings.load_snowflake_settings(schema="RAW_ALT")
+    assert snowflake_settings.schema == "RAW_ALT"
+    assert snowflake_settings.database == "EIA_PIPELINE"
+
+    app_settings = settings.load_app_snowflake_settings()
+    assert app_settings.schema == "APP_GOLD"
+
+
+def test_read_optional_float_defaults_and_invalid_input(monkeypatch) -> None:
+    monkeypatch.delenv("ROLLING_HOURS", raising=False)
+    assert settings._read_optional_float("ROLLING_HOURS", 2.0) == 2.0
+
+    monkeypatch.setenv("ROLLING_HOURS", "none")
+    assert settings._read_optional_float("ROLLING_HOURS", 2.0) == 2.0
+
+    monkeypatch.setenv("ROLLING_HOURS", "bad")
+    with pytest.raises(ValueError):
+        settings._read_optional_float("ROLLING_HOURS", 2.0)
+
+
+def test_load_settings_requires_mandatory_env(monkeypatch) -> None:
+    monkeypatch.delenv("EIA_API_KEY", raising=False)
+    with pytest.raises(KeyError):
+        settings.load_eia_settings()
+
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+    monkeypatch.delenv("SNOWFLAKE_USER", raising=False)
+    monkeypatch.delenv("SNOWFLAKE_PASSWORD", raising=False)
+    with pytest.raises(KeyError):
+        settings.load_snowflake_settings()

--- a/tests/test_ingest_planner.py
+++ b/tests/test_ingest_planner.py
@@ -34,8 +34,10 @@ def test_ingest_planner_treats_incomplete_historical_hourly_partition_as_missing
     plan = ingest_planner.plan_ingest_windows(None, dataset, "EIA_PIPELINE", bootstrap_mode=True)
 
     assert plan.bootstrap_active is True
-    assert plan.ingest_start_date == "2026-04-01"
-    assert "2026-04-01" <= plan.ingest_end_date
+    assert plan.remaining_partitions_estimate == 6
+    assert plan.bootstrap_strategy == "latest_first"
+    assert plan.ingest_start_date == "2026-04-03"
+    assert plan.ingest_end_date == "2026-04-08"
 
 
 def test_transform_planner_excludes_incomplete_historical_hourly_raw_partition(monkeypatch) -> None:

--- a/tests/test_ingestion_modules.py
+++ b/tests/test_ingestion_modules.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from pipeline.core.settings import EiaSettings
+from pipeline.ingestion import client, raw_ingest
+
+
+def test_append_query_value_and_fetch_page(monkeypatch) -> None:
+    query = {}
+    client._append_query_value(query, "data[]", ["value", "other"])
+    assert query == {"data[]": ["value", "other"]}
+
+    captured = {}
+
+    class Response:
+        @staticmethod
+        def raise_for_status():
+            return None
+
+        @staticmethod
+        def json():
+            return {"response": {"data": [{"x": 1}]}}
+
+    monkeypatch.setattr(
+        client.requests,
+        "get",
+        lambda url, params, timeout: captured.update({"url": url, "params": params, "timeout": timeout}) or Response(),
+    )
+
+    settings = EiaSettings(api_key="abc", max_retries=1)
+    page = client.fetch_page(
+        settings,
+        "electricity/rto/region-data",
+        {
+            "data": ["value"],
+            "facets": {"respondent": ["MISO"]},
+            "sort": [{"column": "period", "direction": "desc"}],
+            "length": 500,
+        },
+        "2026-04-09T00",
+        "2026-04-09T23",
+        500,
+    )
+
+    assert page == [{"x": 1}]
+    assert captured["params"]["data[]"] == ["value"]
+    assert captured["params"]["facets[respondent][]"] == ["MISO"]
+    assert captured["params"]["sort[0][column]"] == "period"
+
+
+def test_fetch_page_retries_and_fetch_all_pages(monkeypatch) -> None:
+    attempts = {"count": 0}
+
+    def flaky_get(*args, **kwargs):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise client.requests.RequestException("retry")
+
+        class Response:
+            @staticmethod
+            def raise_for_status():
+                return None
+
+            @staticmethod
+            def json():
+                return {"response": {"data": [{"page": attempts["count"]}]}}
+
+        return Response()
+
+    monkeypatch.setattr(client.requests, "get", flaky_get)
+    monkeypatch.setattr(client.time, "sleep", lambda *_args, **_kwargs: None)
+    settings = EiaSettings(api_key="abc", max_retries=2, retry_backoff_seconds=1)
+    assert client.fetch_page(settings, "route", {}, "s", "e") == [{"page": 2}]
+
+    pages = [[{"id": 1}, {"id": 2}], [{"id": 3}], []]
+    monkeypatch.setattr(client, "fetch_page", lambda *args, **kwargs: pages.pop(0))
+    dataset = {"id": "ds", "eia_route": "route", "params": {"length": 2}}
+    assert client.fetch_all_pages(settings, dataset, start="s", end="e") == [{"id": 1}, {"id": 2}, {"id": 3}]
+
+
+def test_raw_ingest_dataset_selection_chunking_and_run(monkeypatch) -> None:
+    dataset = {
+        "id": "electricity_generation_hourly",
+        "frequency": "hourly",
+        "snowflake_table": "RAW.TABLE",
+        "params": {"facets": {"respondent": ["A", "B", "C"]}},
+        "facet_chunk_key": "respondent",
+        "facet_chunk_size": 2,
+    }
+    monkeypatch.setattr(raw_ingest, "iter_ingest_datasets", lambda: [dataset])
+    monkeypatch.setattr(raw_ingest, "get_dataset", lambda dataset_id: dataset)
+    assert raw_ingest.select_datasets() == [dataset]
+    assert raw_ingest.select_datasets("electricity_generation_hourly") == [dataset]
+
+    enriched = raw_ingest.enrich_records([{"x": 1}], "ds")
+    assert enriched[0]["_dataset_id"] == "ds"
+    assert "_fetched_at" in enriched[0]
+
+    chunked = raw_ingest._chunked_datasets(dataset)
+    assert len(chunked) == 2
+    assert chunked[0]["params"]["facets"]["respondent"] == ["A", "B"]
+
+    monkeypatch.setattr(raw_ingest, "resolve_ingest_windows", lambda *args, **kwargs: [("2026-04-09T00", "2026-04-09T23")])
+    monkeypatch.setattr(raw_ingest, "fetch_all_pages", lambda *args, **kwargs: [{"x": 1}, {"x": 2}])
+    monkeypatch.setattr(raw_ingest, "write_raw_records", lambda *args, **kwargs: len(args[2]))
+    total = raw_ingest.ingest_dataset(None, object(), dataset, start_date="2026-04-09", end_date="2026-04-09")
+    assert total == 4
+
+    monkeypatch.setattr(raw_ingest, "ingest_dataset", lambda *args, **kwargs: 3)
+    assert raw_ingest.run_ingestion(None, object(), target_dataset_id="electricity_generation_hourly") == 3

--- a/tests/test_orchestration_runtime.py
+++ b/tests/test_orchestration_runtime.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pipeline.orchestration import bootstrap_runtime, ingest_runtime, transform_runtime, validation_runtime
+
+
+def test_bootstrap_runtime_helpers(monkeypatch) -> None:
+    assert bootstrap_runtime.should_continue_bootstrap({"a": {"has_more_bootstrap_work": True}}, progress_made=True) is True
+    assert bootstrap_runtime.should_continue_bootstrap({}, progress_made=True) is False
+    assert bootstrap_runtime.should_trigger_matching_transform(
+        {
+            "trigger_matching_transform": True,
+            "dataset_plans": {"d": {"bootstrap_active": True}},
+        },
+        {"d": {"written": 1}},
+        {"d": {}},
+    ) is True
+    assert bootstrap_runtime.chain_depth_exhausted({"bootstrap_chain_depth": "10"}) is True
+
+    conf = bootstrap_runtime.next_bootstrap_conf({"bootstrap_chain_depth": "2"}, source_dag_id="ingest", source_dag_run_id="run:1")
+    assert conf["bootstrap_chain_depth"] == 3
+    assert conf["bootstrap_chain_origin"] == "ingest"
+
+    monkeypatch.setattr(bootstrap_runtime, "build_trigger_run_id", lambda *args, **kwargs: "triggered-id")
+    monkeypatch.setattr(bootstrap_runtime, "has_active_dag_run", lambda *args, **kwargs: False)
+    called = {}
+    import sys, types
+
+    trigger_module = types.ModuleType("airflow.api.common.trigger_dag")
+    trigger_module.trigger_dag = lambda **kwargs: called.update(kwargs)
+    sys.modules["airflow.api.common.trigger_dag"] = trigger_module
+
+    result = bootstrap_runtime.trigger_dag_if_idle("dag", conf={"bootstrap_chain_depth": "2"}, source_run_id="source:run")
+    assert result["triggered"] is True
+    assert called["run_id"] == "triggered-id"
+
+
+def test_ingest_runtime_plan_run_and_finalize(monkeypatch) -> None:
+    datasets = [
+        {"id": "electricity_generation_hourly", "frequency": "hourly"},
+        {"id": "electricity_demand_hourly", "frequency": "hourly"},
+    ]
+    monkeypatch.setattr(ingest_runtime, "iter_scheduled_ingest_cadence_datasets", lambda cadence: list(datasets))
+    monkeypatch.setattr(
+        ingest_runtime,
+        "plan_ingest_windows",
+        lambda *args, **kwargs: type(
+            "Plan",
+            (),
+            {
+                "dataset_id": args[1]["id"],
+                "frequency": "hourly",
+                "bootstrap_ingest_complete": False,
+                "bootstrap_active": True,
+                "bootstrap_strategy": "latest_first",
+                "bootstrap_batch_start": "2026-04-08",
+                "bootstrap_batch_end": "2026-04-09",
+                "remaining_partitions_estimate": 3,
+                "latest_target_partition": "2026-04-09",
+                "has_more_bootstrap_work": True,
+                "ingest_start_date": "2026-04-08",
+                "ingest_end_date": "2026-04-09",
+                "current_partition": "2026-04-09",
+            },
+        )(),
+    )
+    monkeypatch.setattr(ingest_runtime, "ingest_dataset", lambda *args, **kwargs: 5)
+    monkeypatch.setattr(ingest_runtime, "_utc_now", lambda: "2026-04-09T12:00:00")
+    monkeypatch.setattr(ingest_runtime, "get_pipeline_state", lambda *args, **kwargs: {"bootstrap_ingest_complete": False})
+    captured = []
+    monkeypatch.setattr(ingest_runtime, "update_ingest_state", lambda *args, **kwargs: captured.append(kwargs))
+
+    plan = ingest_runtime.plan_ingest_cadence(None, "EIA_PIPELINE", "hourly", {"bootstrap_mode": "yes"})
+    summary = ingest_runtime.run_ingest_cadence(None, object(), "EIA_PIPELINE", "hourly", plan)
+    finalized = ingest_runtime.finalize_ingest_state(None, "EIA_PIPELINE", "hourly", plan, summary)
+
+    assert plan["bootstrap_mode"] is True
+    assert summary["electricity_generation_hourly"]["written"] == 5
+    assert finalized["electricity_generation_hourly"]["has_more_bootstrap_work"] is True
+    assert captured[0]["last_ingest_succeeded_at"] == "2026-04-09T12:00:00"
+
+
+def test_transform_runtime_plan_build_and_finalize(monkeypatch) -> None:
+    datasets = [{"id": "electricity_generation_hourly", "frequency": "hourly"}]
+    monkeypatch.setattr(transform_runtime, "iter_scheduled_transform_cadence_datasets", lambda cadence: list(datasets))
+    monkeypatch.setattr(
+        transform_runtime,
+        "plan_transform_partitions",
+        lambda *args, **kwargs: type(
+            "Plan",
+            (),
+            {
+                "dataset_id": "electricity_generation_hourly",
+                "frequency": "hourly",
+                "bootstrap_transform_complete": False,
+                "bootstrap_active": True,
+                "bootstrap_priority": "latest_first",
+                "scan_start_date": "2026-04-08",
+                "scan_end_date": "2026-04-09",
+                "planned_partitions": ["2026-04-09"],
+                "pending_partitions": ["2026-04-09"],
+                "stale_partitions": [],
+                "remaining_pending_count": 0,
+                "remaining_stale_count": 0,
+                "raw_latest_partition": "2026-04-09",
+                "current_partition": "2026-04-09",
+                "has_more_bootstrap_work": False,
+            },
+        )(),
+    )
+    monkeypatch.setattr(transform_runtime, "run_silver_partitions", lambda *args, **kwargs: [{"partition_date": "2026-04-09"}])
+    monkeypatch.setattr(transform_runtime, "run_gold_partitions", lambda *args, **kwargs: {"2026-04-09": {"fact_generation_hourly": 1}})
+    monkeypatch.setattr(transform_runtime, "refresh_gold_dimensions", lambda *args, **kwargs: {"dim_fuel_type": 2})
+    monkeypatch.setattr(transform_runtime, "_utc_now", lambda: "2026-04-09T12:00:00")
+    monkeypatch.setattr(
+        transform_runtime,
+        "get_pipeline_state",
+        lambda *args, **kwargs: {"bootstrap_transform_complete": False, "last_silver_partition": None, "last_gold_partition": None},
+    )
+    captured = []
+    monkeypatch.setattr(transform_runtime, "update_transform_state", lambda *args, **kwargs: captured.append(kwargs))
+
+    plan = transform_runtime.plan_transform_cadence(None, "EIA_PIPELINE", "hourly", {"bootstrap_mode": "yes"})
+    silver_summary = transform_runtime.build_silver_for_cadence(None, "EIA_PIPELINE", "hourly", plan)
+    gold_summary = transform_runtime.build_gold_for_cadence(None, "EIA_PIPELINE", "hourly", silver_summary)
+    dims = transform_runtime.refresh_cadence_dimensions(None, "EIA_PIPELINE", "hourly")
+    finalized = transform_runtime.finalize_transform_state(None, "EIA_PIPELINE", "hourly", plan, silver_summary, gold_summary)
+
+    assert silver_summary["gold_partitions"] == ["2026-04-09"]
+    assert gold_summary["results"]["2026-04-09"]["fact_generation_hourly"] == 1
+    assert dims["dim_fuel_type"] == 2
+    assert finalized["electricity_generation_hourly"]["bootstrap_transform_complete"] is True
+    assert captured[0]["last_gold_partition"] == "2026-04-09"
+
+
+def test_validation_runtime_helpers_and_error_paths(monkeypatch, tmp_path) -> None:
+    monkeypatch.setenv("DBT_SNOWFLAKE_ACCOUNT", "acct")
+    monkeypatch.setenv("DBT_SNOWFLAKE_USER", "user")
+    monkeypatch.setenv("DBT_SNOWFLAKE_PASSWORD", "pw")
+    monkeypatch.setenv("DBT_THREADS", "8")
+    monkeypatch.setenv("DBT_PROJECT_DIR", str(tmp_path))
+
+    assert validation_runtime._default_project_dir() == tmp_path.resolve()
+    assert validation_runtime._default_target() == "default"
+    assert validation_runtime._default_threads() == 8
+    assert "threads: 8" in validation_runtime._build_profiles_yml("qa")
+    assert validation_runtime._selector_for_cadence("hourly") == "hourly_full_validation"
+    assert validation_runtime._freshness_selector_for_cadence("monthly") == "freshness_monthly_raw"
+    assert validation_runtime._partitions_for_plan({"dataset_plans": {"a": {"planned_partitions": ["2026-04-09", ""]}}}) == ["2026-04-09"]
+    assert validation_runtime._build_dbt_vars({"cadence_group": "hourly", "bootstrap_mode": 1})["bootstrap_mode"] is True
+    assert validation_runtime._load_json_artifact(tmp_path / "missing.json") == {}
+    assert validation_runtime._artifact_summary({}, artifact_type="tests")["status"] == "missing"
+
+    artifact = {"results": [{"unique_id": "x", "status": "pass", "message": "ok"}]}
+    assert validation_runtime._artifact_summary(artifact, artifact_type="tests")["counts"] == {"pass": 1}
+
+    selectors_file = Path("warehouse/dbt/selectors.yml").read_text(encoding="utf-8")
+    for selector in (
+        "hourly_generation_validation",
+        "hourly_demand_validation",
+        "monthly_retail_sales_validation",
+        "monthly_power_operational_validation",
+    ):
+        assert selector in selectors_file
+
+    monkeypatch.setattr(validation_runtime, "_default_project_dir", lambda: tmp_path)
+    monkeypatch.setattr(validation_runtime, "_resolve_dbt_binary", lambda: "dbt")
+    with pytest.raises(validation_runtime.DbtValidationError):
+        validation_runtime.run_dbt_validation({"cadence_group": ""})
+
+    with pytest.raises(validation_runtime.DbtValidationError):
+        validation_runtime._selector_for_cadence("weekly")
+
+
+def test_validation_runtime_full_run_with_mocked_dbt(monkeypatch, tmp_path) -> None:
+    target_dir = tmp_path / "target"
+    target_dir.mkdir()
+    (target_dir / "sources.json").write_text('{"sources":[{"unique_id":"s","status":"pass"}]}', encoding="utf-8")
+    (target_dir / "run_results.json").write_text('{"results":[{"unique_id":"t","status":"pass"}]}', encoding="utf-8")
+    monkeypatch.setenv("DBT_SNOWFLAKE_ACCOUNT", "acct")
+    monkeypatch.setenv("DBT_SNOWFLAKE_USER", "user")
+    monkeypatch.setenv("DBT_SNOWFLAKE_PASSWORD", "pw")
+    monkeypatch.setattr(validation_runtime, "_default_project_dir", lambda: tmp_path)
+    monkeypatch.setattr(validation_runtime, "_resolve_dbt_binary", lambda: "dbt")
+    calls = []
+    monkeypatch.setattr(
+        validation_runtime,
+        "_run_dbt_command",
+        lambda command, **kwargs: calls.append(command) or type("Completed", (), {"returncode": 0})(),
+    )
+
+    summary = validation_runtime.run_dbt_validation(
+        {
+            "cadence_group": "hourly",
+            "override_start_date": "2026-04-08",
+            "override_end_date": "2026-04-09",
+            "selected_dataset": "electricity_generation_hourly",
+            "bootstrap_mode": False,
+            "dataset_plans": {"electricity_generation_hourly": {"planned_partitions": ["2026-04-09"]}},
+        }
+    )
+
+    assert summary["freshness"]["counts"] == {"pass": 1}
+    assert summary["tests"]["counts"] == {"pass": 1}
+    assert [item["name"] for item in summary["commands"]] == ["deps", "source_freshness", "test"]
+    assert any("freshness_hourly_generation" in part for command in calls for part in command)

--- a/tests/test_registry_and_bootstrap.py
+++ b/tests/test_registry_and_bootstrap.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import sys
+import types
+
+from pipeline.core import registry
+from pipeline.orchestration import bootstrap_runtime
+
+
+def test_registry_filters_and_lookup(monkeypatch) -> None:
+    datasets = [
+        {
+            "id": "electricity_generation_hourly",
+            "frequency": "hourly",
+            "cadence_group": "hourly",
+            "transform_enabled": True,
+            "scheduled_ingest": True,
+            "scheduled_transform": True,
+            "snowflake_table": "GEN_RAW",
+        },
+        {
+            "id": "electricity_retail_sales_monthly",
+            "frequency": "monthly",
+            "cadence_group": "monthly",
+            "transform_enabled": True,
+            "scheduled_ingest": False,
+            "scheduled_transform": False,
+            "snowflake_table": "SALES_RAW",
+        },
+    ]
+    monkeypatch.setattr(registry, "load_registry", lambda: list(datasets))
+
+    assert registry.normalize_dataset_id("electricity_generation_hourly") == "electricity_generation"
+    assert registry.iter_datasets() == datasets
+    assert registry.iter_ingest_datasets() == datasets
+    assert registry.iter_transform_datasets() == datasets
+    assert registry.iter_cadence_datasets("hourly") == [datasets[0]]
+    assert registry.iter_scheduled_ingest_datasets() == [datasets[0]]
+    assert registry.iter_scheduled_transform_datasets() == [datasets[0]]
+    assert registry.iter_scheduled_cadence_datasets("hourly") == [datasets[0]]
+    assert registry.iter_scheduled_ingest_cadence_datasets("hourly") == [datasets[0]]
+    assert registry.iter_scheduled_transform_cadence_datasets("hourly") == [datasets[0]]
+    assert registry.iter_monthly_ingest_datasets() == [datasets[1]]
+    assert registry.iter_monthly_transform_datasets() == [datasets[1]]
+    assert registry.get_dataset("electricity_generation_hourly") == datasets[0]
+    assert registry.get_raw_table_name("electricity_generation_hourly") == "GEN_RAW"
+    assert registry.get_silver_table_name("electricity_generation_hourly") == "SILVER_ELECTRICITY_GENERATION"
+
+
+def test_bootstrap_active_run_helpers(monkeypatch) -> None:
+    class FakeField:
+        def __eq__(self, other):
+            return ("eq", other)
+
+        def in_(self, values):
+            return ("in", tuple(values))
+
+        def __ne__(self, other):
+            return ("ne", other)
+
+    class DagRun:
+        dag_id = FakeField()
+        state = FakeField()
+        run_id = FakeField()
+
+    class Query:
+        def __init__(self):
+            self.has_row = True
+
+        def filter(self, *args, **kwargs):
+            return self
+
+        def limit(self, _n):
+            return self
+
+        def first(self):
+            return object() if self.has_row else None
+
+    class FakeSession:
+        def __init__(self):
+            self.query_obj = Query()
+            self.closed = False
+
+        def query(self, model):
+            return self.query_obj
+
+        def close(self):
+            self.closed = True
+
+    session = FakeSession()
+    airflow_models = types.ModuleType("airflow.models")
+    airflow_models.DagRun = DagRun
+    airflow_settings = types.ModuleType("airflow.settings")
+    airflow_settings.Session = lambda: session
+    sys.modules["airflow.models"] = airflow_models
+    sys.modules["airflow.settings"] = airflow_settings
+
+    assert bootstrap_runtime.has_active_dag_run("dag") is True
+    session.query_obj.has_row = False
+    assert bootstrap_runtime.has_active_dag_run("dag", exclude_run_id="run-1") is False
+
+    monkeypatch.setattr(bootstrap_runtime, "has_active_dag_run", lambda *args, **kwargs: True)
+    result = bootstrap_runtime.trigger_dag_if_idle("dag", conf={"bootstrap_chain_depth": "1"}, source_run_id="run")
+    assert result == {"triggered": False, "reason": "active_run_exists", "dag_id": "dag"}

--- a/tests/test_transform_helpers.py
+++ b/tests/test_transform_helpers.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from pipeline.gold import transform as gold_transform
+from pipeline.silver import transform as silver_transform
+
+
+def test_silver_helper_functions(fake_session, monkeypatch) -> None:
+    assert silver_transform._full_dataset_id("electricity_generation") == "electricity_generation_hourly"
+    assert silver_transform._normalized_partition_date("electricity_retail_sales", "2026-04-19") == "2026-04-01"
+
+    fake_session.tables["DB.SILVER.TABLE"] = SimpleNamespace(schema=SimpleNamespace(names=["A", "B"]), limit=lambda _n: SimpleNamespace(collect=lambda: []))
+    monkeypatch.setattr(silver_transform, "table_exists", lambda *args, **kwargs: True)
+    assert silver_transform._table_needs_replace(fake_session, "DB.SILVER.TABLE", ["a", "b"]) is False
+    assert silver_transform._table_needs_replace(fake_session, "DB.SILVER.TABLE", ["a"]) is True
+
+    silver_transform._delete_partition_if_present(fake_session, "DB.SILVER.TABLE", "2026-04-09")
+    assert "delete from DB.SILVER.TABLE where partition_date = '2026-04-09'" in fake_session.sql_calls[-1]
+
+    df = SimpleNamespace(
+        schema=SimpleNamespace(names=["period"]),
+        count=lambda: 2,
+        write=SimpleNamespace(
+            mode=lambda mode_name: SimpleNamespace(
+                save_as_table=lambda table_name, **kwargs: None
+            )
+        ),
+        with_column=lambda *args, **kwargs: df,
+    )
+    monkeypatch.setattr(silver_transform, "_table_needs_replace", lambda *args, **kwargs: False)
+    monkeypatch.setattr(silver_transform, "_delete_partition_if_present", lambda *args, **kwargs: fake_session.sql_calls.append("deleted"))
+    assert silver_transform._write_partitioned_table(fake_session, df, "DB.TABLE", "2026-04-09", ["period"]) == 2
+
+
+def test_silver_read_and_run_paths(monkeypatch) -> None:
+    hourly_df = SimpleNamespace(filter=lambda expr: ("hourly", expr))
+    monthly_df = SimpleNamespace(filter=lambda expr: ("monthly", expr))
+    session = SimpleNamespace(table=lambda name: hourly_df if "RAW_GEN" in name else monthly_df)
+
+    assert silver_transform.read_raw_for_business_date(session, "electricity_generation", "RAW_GEN", "2026-04-09")[0] == "hourly"
+    assert silver_transform.read_raw_for_business_date(session, "electricity_retail_sales", "RAW_MONTH", "2026-04-19")[0] == "monthly"
+
+    dedup_df = SimpleNamespace(schema=SimpleNamespace(names=["period"]), count=lambda: 3)
+    monkeypatch.setattr(silver_transform, "read_raw_for_business_date", lambda *args, **kwargs: "raw")
+    monkeypatch.setattr(silver_transform, "clean_generation", lambda df: "clean")
+    monkeypatch.setattr(silver_transform, "_deduplicate", lambda df, dataset: dedup_df)
+    monkeypatch.setattr(silver_transform, "_write_partitioned_table", lambda *args, **kwargs: 3)
+    monkeypatch.setattr(silver_transform, "get_raw_table_name", lambda dataset_id: "RAW_GEN")
+    monkeypatch.setattr(silver_transform, "get_silver_table_name", lambda dataset_id: "SILVER_GEN")
+
+    assert silver_transform.run_silver(None, "electricity_generation", "2026-04-09", "EIA_PIPELINE") == 3
+
+    raw_df = SimpleNamespace(count=lambda: 5)
+    dedup_df2 = SimpleNamespace(schema=SimpleNamespace(names=["period"]), count=lambda: 3)
+    monkeypatch.setattr(silver_transform, "read_raw_for_business_date", lambda *args, **kwargs: raw_df)
+    monkeypatch.setattr(silver_transform, "clean_retail_sales", lambda df: "clean")
+    monkeypatch.setattr(silver_transform, "_deduplicate", lambda df, dataset: dedup_df2)
+    monkeypatch.setattr(silver_transform, "_write_partitioned_table", lambda *args, **kwargs: 3)
+    results = silver_transform.run_silver_partitions(None, "electricity_retail_sales", ["2026-04-19"], "EIA_PIPELINE")
+    assert results == [{"partition_date": "2026-04-01", "rows_read": 5, "rows_written": 3, "duplicates_removed": 2}]
+
+
+def test_gold_helpers_and_run_paths(monkeypatch) -> None:
+    assert gold_transform._silver_table("EIA_PIPELINE", "SILVER_X") == "EIA_PIPELINE.SILVER.SILVER_X"
+    assert gold_transform._gold_table("EIA_PIPELINE", "FACT_X") == "EIA_PIPELINE.GOLD.FACT_X"
+
+    fake_pd_df = SimpleNamespace(
+        select=lambda *args: fake_pd_df,
+        dropna=lambda subset=None: fake_pd_df,
+        drop_duplicates=lambda cols: fake_pd_df,
+        filter=lambda expr: fake_pd_df,
+    )
+    assert gold_transform._stabilize_generation(fake_pd_df) is fake_pd_df
+    assert gold_transform._stabilize_demand(fake_pd_df) is fake_pd_df
+    assert gold_transform._stabilize_monthly_sales(fake_pd_df) is fake_pd_df
+    assert gold_transform._stabilize_monthly_ops(fake_pd_df) is fake_pd_df
+    monkeypatch.setattr(gold_transform, "lit", lambda value: value)
+    monkeypatch.setattr(gold_transform, "sf_round", lambda value, scale: ("round", value, scale))
+
+    class _When:
+        def __init__(self, condition, value):
+            self.condition = condition
+            self.value = value
+
+        def otherwise(self, other):
+            return ("when", self.condition, self.value, other)
+
+    monkeypatch.setattr(gold_transform, "when", lambda condition, value: _When(condition, value))
+    assert gold_transform._safe_pct(1, 2) == ("when", True, ("round", 50.0, 2), None)
+
+    monkeypatch.setattr(gold_transform, "_build_hourly_generation_partition", lambda *args, **kwargs: {"fact_generation_hourly": 1})
+    monkeypatch.setattr(gold_transform, "_build_hourly_demand_partition", lambda *args, **kwargs: {"fact_demand_hourly": 2})
+    monkeypatch.setattr(gold_transform, "_build_monthly_operational_sales", lambda *args, **kwargs: {"fact_sales_monthly": 3})
+    monkeypatch.setattr(gold_transform, "get_gold_table_names", lambda: {"fact_generation_hourly": "FG", "fact_demand_hourly": "FD", "fact_sales_monthly": "FSM"})
+    monkeypatch.setattr(gold_transform, "refresh_gold_dimensions", lambda *args, **kwargs: {"dim_balancing_authority": 2})
+
+    results = gold_transform.run_gold_partitions(None, database="EIA_PIPELINE", target_dates=["2026-04-09"], scope="all")
+    assert results["2026-04-09"]["fact_sales_monthly"] == 3
+    assert gold_transform.run_gold(None, "2026-04-09", "EIA_PIPELINE", scope="hourly")["fact_generation_hourly"] == 1
+
+
+def test_gold_dimension_refresh_and_monthly_builder(monkeypatch) -> None:
+    dim_frame = SimpleNamespace(
+        select=lambda *args: dim_frame,
+        drop_duplicates=lambda cols: dim_frame,
+        union=lambda other: dim_frame,
+    )
+    session = SimpleNamespace(table=lambda name: dim_frame)
+    monkeypatch.setattr(gold_transform, "table_exists", lambda session, table_name: True)
+    monkeypatch.setattr(gold_transform, "_write_dimension_table", lambda df, name: 4)
+    monkeypatch.setattr(
+        gold_transform,
+        "get_gold_table_names",
+        lambda: {
+            "fact_generation_hourly": "FACT_GENERATION_HOURLY",
+            "fact_demand_hourly": "FACT_DEMAND_HOURLY",
+            "dim_balancing_authority": "DIM_BALANCING_AUTHORITY",
+            "dim_fuel_type": "DIM_FUEL_TYPE",
+        },
+    )
+    refreshed = gold_transform.refresh_gold_dimensions(session, database="EIA_PIPELINE", scope="hourly")
+    assert refreshed == {"dim_balancing_authority": 4, "dim_fuel_type": 4}
+
+    empty_frame = SimpleNamespace(filter=lambda expr: empty_frame, count=lambda: 0)
+    session2 = SimpleNamespace(table=lambda name: empty_frame)
+    monkeypatch.setattr(gold_transform, "table_exists", lambda *args, **kwargs: True)
+    monkeypatch.setattr(gold_transform, "_stabilize_monthly_sales", lambda df: empty_frame)
+    monkeypatch.setattr(gold_transform, "_stabilize_monthly_ops", lambda df: empty_frame)
+    assert gold_transform._build_monthly_operational_sales(
+        session2,
+        "EIA_PIPELINE",
+        "2026-04-19",
+        {"fact_sales_monthly": "FACT_SALES_MONTHLY"},
+    ) == {}


### PR DESCRIPTION
## Summary
- add repo-level pytest and coverage configuration
- add mocked unit coverage across pipeline core, orchestration, ingestion, silver, and gold paths
- enforce a 70% pipeline coverage gate and keep default test runs root-level

## Verification
- pytest -q
- pipeline coverage: 84.44%